### PR TITLE
feat: Study 목록 API 추가

### DIFF
--- a/http/study.http
+++ b/http/study.http
@@ -1,1 +1,5 @@
 # 스터디 관련 API를 테스트하는 HTTP 요청 파일입니다.
+
+###
+
+GET http://localhost:3000/study?offset=0&pointOrder=desc&recentOrder=recent

--- a/src/api/controllers/study.controllers.js
+++ b/src/api/controllers/study.controllers.js
@@ -1,1 +1,31 @@
 // 요청 파싱(params/query/body) + 입력 검증 결과 처리
+import studyService from '../services/Study.Services.js';
+
+// 스터디 목록 조회 API
+async function controllStudyList(req, res) {
+  /* 쿼리 파라미터 파싱 */
+  const offset = parseInt(req.query.offset, 10) || 0;
+  const keyword = req.query.keyword || '';
+  const pointOrder = req.query.pointOrder || 'asc';
+  const recentOrder = req.query.recentOrder || 'recent';
+
+  /* 입력 검증 */
+  const validPointOrders = ['asc', 'desc'].includes(pointOrder)
+    ? pointOrder
+    : 'asc'; // 포인트 정렬 필드 검증
+  const validRecentOrders = ['recent', 'old'].includes(recentOrder)
+    ? recentOrder
+    : 'recent'; // 기간 정렬 필드 검증
+
+  // 서비스 호출
+  const studyList = await studyService.serviceStudyList({
+    offset,
+    keyword,
+    pointOrder: validPointOrders,
+    recentOrder: validRecentOrders,
+  });
+
+  res.json(studyList);
+}
+
+export default { controllStudyList };

--- a/src/api/controllers/study.controllers.js
+++ b/src/api/controllers/study.controllers.js
@@ -2,7 +2,7 @@
 import studyService from '../services/Study.Services.js';
 
 // 스터디 목록 조회 API
-async function controllStudyList(req, res) {
+async function controlStudyList(req, res) {
   /* 쿼리 파라미터 파싱 */
   const offset = parseInt(req.query.offset, 10) || 0;
   const keyword = req.query.keyword || '';
@@ -28,4 +28,4 @@ async function controllStudyList(req, res) {
   res.json(studyList);
 }
 
-export default { controllStudyList };
+export default { controlStudyList };

--- a/src/api/controllers/study.controllers.js
+++ b/src/api/controllers/study.controllers.js
@@ -3,28 +3,32 @@ import studyService from '../services/study.services.js';
 
 // 스터디 목록 조회 API
 async function controlStudyList(req, res) {
-  /* 쿼리 파라미터 파싱 */
-  const offset = parseInt(req.query.offset, 10) || 0;
-  const limit = parseInt(req.query.limit, 10) || 6; // 기본값 6
-  const keyword = req.query.keyword || '';
-  const pointOrder = req.query.pointOrder || 'asc';
-  const recentOrder = req.query.recentOrder || 'recent';
-
-  /* 입력 검증 */
-  const validPointOrders = ['asc', 'desc'].includes(pointOrder)
-    ? pointOrder
-    : 'asc'; // 포인트 정렬 필드 검증
-  const validRecentOrders = ['recent', 'old'].includes(recentOrder)
-    ? recentOrder
-    : 'recent'; // 기간 정렬 필드 검증
+  /* 쿼리 파라미터 파싱 및 입력 검증 */
+  const offsetRaw = Number.parseInt(req.query.offset ?? '0', 10);
+  const limitRaw = Number.parseInt(req.query.limit ?? '6', 10);
+  const offset = Number.isFinite(offsetRaw) && offsetRaw >= 0 ? offsetRaw : 0;
+  const limit =
+    Number.isFinite(limitRaw) && limitRaw > 0 ? Math.min(limitRaw, 50) : 6; // 상한 50
+  const keyword =
+    typeof req.query.keyword === 'string' ? req.query.keyword.trim() : '';
+  const pointOrderRaw =
+    typeof req.query.pointOrder === 'string'
+      ? req.query.pointOrder.toLowerCase()
+      : 'asc';
+  const recentOrderRaw =
+    typeof req.query.recentOrder === 'string'
+      ? req.query.recentOrder.toLowerCase()
+      : 'recent';
+  const pointOrder = pointOrderRaw === 'desc' ? 'desc' : 'asc';
+  const recentOrder = recentOrderRaw === 'old' ? 'old' : 'recent';
 
   // 서비스 호출
   const studyList = await studyService.serviceStudyList({
     offset,
     limit,
     keyword,
-    pointOrder: validPointOrders,
-    recentOrder: validRecentOrders,
+    pointOrder,
+    recentOrder,
   });
 
   res.json(studyList);

--- a/src/api/controllers/study.controllers.js
+++ b/src/api/controllers/study.controllers.js
@@ -1,10 +1,11 @@
 // 요청 파싱(params/query/body) + 입력 검증 결과 처리
-import studyService from '../services/Study.Services.js';
+import studyService from '../services/study.services.js';
 
 // 스터디 목록 조회 API
 async function controlStudyList(req, res) {
   /* 쿼리 파라미터 파싱 */
   const offset = parseInt(req.query.offset, 10) || 0;
+  const limit = parseInt(req.query.limit, 10) || 6; // 기본값 6
   const keyword = req.query.keyword || '';
   const pointOrder = req.query.pointOrder || 'asc';
   const recentOrder = req.query.recentOrder || 'recent';
@@ -20,6 +21,7 @@ async function controlStudyList(req, res) {
   // 서비스 호출
   const studyList = await studyService.serviceStudyList({
     offset,
+    limit,
     keyword,
     pointOrder: validPointOrders,
     recentOrder: validRecentOrders,

--- a/src/api/routes/study.routes.js
+++ b/src/api/routes/study.routes.js
@@ -1,21 +1,33 @@
 // Description: API를 위한 라우터 설정 코드 파일입니다.
+// 라이브러리 정의
 import express from 'express';
 import { Prisma } from '@prisma/client';
-import coreMiddleware from '../../../src/common/cors.js';
+
+// 미들웨어 정의
+import corsMiddleware from '../../../src/common/cors.js';
 import errorMiddleware from '../../../src/common/error.js'; // 에러를 추가할 일이 있다면, 해당 파일에 케이스를 추가해주시기 바랍니다.
+
+// 컨트롤러 정의
+import studyController from '../controllers/study.controllers.js';
 
 const router = express.Router();
 
-router.use(coreMiddleware); // CORS 미들웨어 적용
+router.use(corsMiddleware); // CORS 미들웨어 적용
 router.use(express.json());
 
-// 예시 API 엔드포인트
+// 스터디 목록 조회 API 엔드포인트
 router.get(
-  '/example-API',
-  errorMiddleware.asyncHandler(async (req, res) => {
-    res.json({ status: 'OK', message: 'This is example API' });
-  }),
+  '/',
+  errorMiddleware.asyncHandler(studyController.controllStudyList),
 );
+
+// // 예시 API 엔드포인트
+// router.get(
+//   '/example-API',
+//   errorMiddleware.asyncHandler(async (req, res) => {
+//     res.json({ status: 'OK', message: 'This is example API' });
+//   }),
+// );
 
 // 에러 핸들링 미들웨어 적용, 가장 마지막에 위치해야 합니다.
 router.use(errorMiddleware.errorHandler);

--- a/src/api/routes/study.routes.js
+++ b/src/api/routes/study.routes.js
@@ -1,7 +1,6 @@
 // Description: API를 위한 라우터 설정 코드 파일입니다.
 // 라이브러리 정의
 import express from 'express';
-import { Prisma } from '@prisma/client';
 
 // 미들웨어 정의
 import corsMiddleware from '../../../src/common/cors.js';
@@ -16,10 +15,7 @@ router.use(corsMiddleware); // CORS 미들웨어 적용
 router.use(express.json());
 
 // 스터디 목록 조회 API 엔드포인트
-router.get(
-  '/',
-  errorMiddleware.asyncHandler(studyController.controllStudyList),
-);
+router.get('/', errorMiddleware.asyncHandler(studyController.controlStudyList));
 
 // // 예시 API 엔드포인트
 // router.get(

--- a/src/api/routes/study.routes.js
+++ b/src/api/routes/study.routes.js
@@ -3,8 +3,8 @@
 import express from 'express';
 
 // 미들웨어 정의
-import corsMiddleware from '../../../src/common/cors.js';
-import errorMiddleware from '../../../src/common/error.js'; // 에러를 추가할 일이 있다면, 해당 파일에 케이스를 추가해주시기 바랍니다.
+import corsMiddleware from '../../common/cors.js';
+import errorMiddleware from '../../common/error.js'; // 에러를 추가할 일이 있다면, 해당 파일에 케이스를 추가해주시기 바랍니다.
 
 // 컨트롤러 정의
 import studyController from '../controllers/study.controllers.js';

--- a/src/api/services/study.services.js
+++ b/src/api/services/study.services.js
@@ -43,6 +43,7 @@ async function serviceStudyList(options) {
           updatedAt: true,
           _count: {
             select: {
+              points: true,
               habitHistories: true,
               focuses: true,
               studyEmojis: true,

--- a/src/api/services/study.services.js
+++ b/src/api/services/study.services.js
@@ -5,19 +5,23 @@ import { PrismaClient } from '@prisma/client';
 const prisma = new PrismaClient();
 
 async function serviceStudyList(options) {
-  const { offset, keyword, pointOrder, recentOrder } = options;
-  const PAGE_SIZE = 6; // 한 번에 가져올 스터디 수
-  const where = { isActive: true };
-
-  try {
-    const [studies, totalCount] = await Promise.all([
-      prisma.study.findMany({
-        where: {
+  const { offset, limit, keyword, pointOrder, recentOrder } = options;
+  const where = {
+    isActive: true,
+    ...(keyword
+      ? {
           name: {
             contains: keyword,
             mode: 'insensitive',
           },
-        },
+        }
+      : {}),
+  };
+
+  try {
+    const [studies, totalCount] = await Promise.all([
+      prisma.study.findMany({
+        where,
         orderBy: [
           {
             points: {
@@ -27,7 +31,7 @@ async function serviceStudyList(options) {
           { createdAt: recentOrder === 'recent' ? 'desc' : 'asc' },
         ],
         skip: offset,
-        take: PAGE_SIZE,
+        take: Math.min(limit, 50),
         select: {
           id: true,
           nick: true,

--- a/src/api/services/study.services.js
+++ b/src/api/services/study.services.js
@@ -6,7 +6,7 @@ const prisma = new PrismaClient();
 
 async function serviceStudyList(options) {
   const { offset, keyword, pointOrder, recentOrder } = options;
-  const PAGE_SIZE = 20; // 한 번에 가져올 스터디 수
+  const PAGE_SIZE = 6; // 한 번에 가져올 스터디 수
   const where = { isActive: true };
 
   try {

--- a/src/api/services/study.services.js
+++ b/src/api/services/study.services.js
@@ -1,2 +1,59 @@
 // 비즈니스 로직의 핵심(도메인 규칙, 트랜잭션, 외부 API 연동)
 // 데이터 접근 계층 호출(Prisma/Mongoose/Raw SQL)
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+async function serviceStudyList(options) {
+  const { offset, keyword, pointOrder, recentOrder } = options;
+  const PAGE_SIZE = 20; // 한 번에 가져올 스터디 수
+  const where = { isActive: true };
+
+  try {
+    const [studies, totalCount] = await Promise.all([
+      prisma.study.findMany({
+        where: {
+          name: {
+            contains: keyword,
+            mode: 'insensitive',
+          },
+        },
+        orderBy: [
+          {
+            points: {
+              _count: pointOrder === 'desc' ? 'desc' : 'asc',
+            },
+          },
+          { createdAt: recentOrder === 'recent' ? 'desc' : 'asc' },
+        ],
+        skip: offset,
+        take: PAGE_SIZE,
+        select: {
+          id: true,
+          nick: true,
+          name: true,
+          content: true,
+          img: true,
+          isActive: true,
+          createdAt: true,
+          updatedAt: true,
+          _count: {
+            select: {
+              habitHistories: true,
+              focuses: true,
+              studyEmojis: true,
+            },
+          },
+        },
+      }),
+      prisma.study.count({ where }),
+    ]);
+
+    return { studies, totalCount };
+  } catch (error) {
+    console.log(error, '가 발생했습니다.');
+    throw error;
+  }
+}
+
+export default { serviceStudyList };

--- a/src/app.js
+++ b/src/app.js
@@ -3,12 +3,31 @@
 //
 // // 라우트 등록
 // app.use('/api/users', userRoutes);
+
+// 환경 변수 관련 라이브러리
+import path from 'path';
+import { fileURLToPath } from 'url';
+import dotenv from 'dotenv';
+
 import express from 'express';
+import morgan from 'morgan';
 import studyRoutes from '../src/api/routes/study.routes.js';
+
+// 환경 변수 설정
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+if (!process.env.DATABASE_URL) {
+  dotenv.config({ path: path.resolve(__dirname, '../.env') });
+  if (!process.env.DATABASE_URL) {
+    console.error('[ENV] DATABASE_URL 로드 실패');
+  }
+}
+
 
 const app = express();
 
-app.use('/api/study', studyRoutes);
+app.use(express.json()); // JSON 파싱 미들웨어 추가
+app.use(morgan('combined'));
+app.use('/study', studyRoutes);
 
 app.listen(3000, () => {
   console.log('Test server is running on port 3000');


### PR DESCRIPTION
- 페이지네이션, 검색 기능, 포인트 순 정렬(오름차순/내림차순), 생성일 정렬(최근순/오래된순) 기능을 이용해 조회
- API부터 테스트에 관련된 URL을 이용하여 개발 완료

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 스터디 목록 조회 API 추가: GET /study (페이징, 키워드 검색, 포인트·최신 정렬, 총 개수 반환)
- 리팩터
  - 기본 엔드포인트 경로를 /api/study에서 /study로 변경
- 테스트
  - 로컬 검증용 HTTP 요청 예시(.http) 추가
- 잡무
  - 요청 로깅(morgan) 및 JSON 파서 미들웨어 도입
  - 환경변수(.env) 로딩 개선 및 누락 시 경고 로그 출력
<!-- end of auto-generated comment: release notes by coderabbit.ai -->