### PR TITLE
feat: Study 추가 API 추가

### DIFF
--- a/http/study.http
+++ b/http/study.http
@@ -3,3 +3,18 @@
 ###
 
 GET http://localhost:3000/study?offset=0&pointOrder=desc&recentOrder=recent
+
+###
+
+POST http://localhost:3000/study
+Content-Type: application/json
+
+{
+    "nick": "테스트",
+    "name": "스터디 생성 테스트",
+    "content": "스터디 생성 테스트 중 입니다.",
+    "img": "https://avatars.githubusercontent.com/in/347564?s=60&v=4",
+    "password": "1234",
+    "checkPassword": "1234",
+    "isActive": true
+}

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   "dependencies": {
     "@faker-js/faker": "^10.0.0",
     "@prisma/client": "^6.15.0",
+    "argon2": "^0.44.0",
     "cors": "^2.8.5",
     "dotenv": "^17.2.1",
     "morgan": "^1.10.1",

--- a/package.json
+++ b/package.json
@@ -34,13 +34,17 @@
     "eslint-plugin-react-hooks": "^4.3.0",
     "husky": "^9.1.7",
     "lint-staged": "^16.1.5",
+    "nodemon": "^3.1.7",
     "prettier": "^3.6.2",
-    "prisma": "^6.15.0",
-    "nodemon": "^3.1.7"
+    "prisma": "^6.15.0"
   },
   "dependencies": {
     "@faker-js/faker": "^10.0.0",
-    "@prisma/client": "^6.15.0"
+    "@prisma/client": "^6.15.0",
+    "cors": "^2.8.5",
+    "dotenv": "^17.2.1",
+    "morgan": "^1.10.1",
+    "superstruct": "^2.0.2"
   },
   "prisma": {
     "schema": "src/prisma/schema.prisma",

--- a/src/api/controllers/study.controllers.js
+++ b/src/api/controllers/study.controllers.js
@@ -43,10 +43,10 @@ async function controlStudyCreate(req, res) {
   const { nick, name, content, img, password, checkPassword, isActive } =
     req.body;
   if (password !== checkPassword) {
-    res
-      .status(400)
-      .json({ error: '비밀번호와 확인용 비밀번호가 일치하지 않습니다.' });
-    return;
+    const err = new Error('비밀번호와 확인용 비밀번호가 일치하지 않습니다.');
+    err.status = 400;
+    err.code = 'PASSWORD_MISMATCH';
+    throw err;
   }
   const passwordHash = await argon2.hash(password);
   /* 서비스 호출 */

--- a/src/api/controllers/study.controllers.js
+++ b/src/api/controllers/study.controllers.js
@@ -1,4 +1,6 @@
 // 요청 파싱(params/query/body) + 입력 검증 결과 처리
+import { assert } from 'superstruct';
+import { createStudy } from '../structs.js';
 import studyService from '../services/study.services.js';
 
 // 스터디 목록 조회 API
@@ -34,4 +36,31 @@ async function controlStudyList(req, res) {
   res.json(studyList);
 }
 
-export default { controlStudyList };
+async function controlStudyCreate(req, res) {
+  /* 입력 검증 */
+  assert(req.body, createStudy);
+  const { nick, name, content, img, password, checkPassword, isActive } =
+    req.body;
+  if (password !== checkPassword) {
+    res
+      .status(400)
+      .json({ error: '비밀번호와 확인용 비밀번호가 일치하지 않습니다.' });
+    return;
+  }
+
+  /* 서비스 호출 */
+
+  const studyCreate = await studyService.serviceStudyCreate(
+    nick,
+    name,
+    content,
+    img,
+    password,
+    isActive,
+  );
+
+  /* 결과 반환 */
+  res.status(200).json(studyCreate);
+}
+
+export default { controlStudyList, controlStudyCreate };

--- a/src/api/controllers/study.controllers.js
+++ b/src/api/controllers/study.controllers.js
@@ -2,6 +2,7 @@
 import { assert } from 'superstruct';
 import { createStudy } from '../structs.js';
 import studyService from '../services/study.services.js';
+import argon2 from 'argon2';
 
 // 스터디 목록 조회 API
 async function controlStudyList(req, res) {
@@ -47,20 +48,19 @@ async function controlStudyCreate(req, res) {
       .json({ error: '비밀번호와 확인용 비밀번호가 일치하지 않습니다.' });
     return;
   }
-
+  const passwordHash = await argon2.hash(password);
   /* 서비스 호출 */
-
   const studyCreate = await studyService.serviceStudyCreate(
     nick,
     name,
     content,
     img,
-    password,
+    passwordHash,
     isActive,
   );
 
   /* 결과 반환 */
-  res.status(200).json(studyCreate);
+  res.status(201).location(`/study/${studyCreate.id}`).json(studyCreate);
 }
 
 export default { controlStudyList, controlStudyCreate };

--- a/src/api/routes/concentrate.routes.js
+++ b/src/api/routes/concentrate.routes.js
@@ -1,13 +1,11 @@
 // Description: API를 위한 라우터 설정 코드 파일입니다.
 import express from 'express';
-import { Prisma } from '@prisma/client';
 import coreMiddleware from '../../../src/common/cors.js';
 import errorMiddleware from '../../../src/common/error.js'; // 에러를 추가할 일이 있다면, 해당 파일에 케이스를 추가해주시기 바랍니다.
 
 const router = express.Router();
 
 router.use(coreMiddleware); // CORS 미들웨어 적용
-router.use(express.json());
 
 // 예시 API 엔드포인트
 router.get(

--- a/src/api/routes/habit.routes.js
+++ b/src/api/routes/habit.routes.js
@@ -1,13 +1,11 @@
 // Description: API를 위한 라우터 설정 코드 파일입니다.
 import express from 'express';
-import { Prisma } from '@prisma/client';
 import coreMiddleware from '../../../src/common/cors.js';
 import errorMiddleware from '../../../src/common/error.js'; // 에러를 추가할 일이 있다면, 해당 파일에 케이스를 추가해주시기 바랍니다.
 
 const router = express.Router();
 
 router.use(coreMiddleware); // CORS 미들웨어 적용
-router.use(express.json());
 
 // 예시 API 엔드포인트
 router.get(

--- a/src/api/routes/study.routes.js
+++ b/src/api/routes/study.routes.js
@@ -12,9 +12,8 @@ import studyController from '../controllers/study.controllers.js';
 const router = express.Router();
 
 router.use(corsMiddleware); // CORS 미들웨어 적용
-router.use(express.json());
+router.use(express.json({ limit: '1mb' }));
 
-/* 스터디 */
 // 스터디 목록 조회 API 엔드포인트
 router.get('/', errorMiddleware.asyncHandler(studyController.controlStudyList));
 
@@ -23,12 +22,6 @@ router.post(
   '/',
   errorMiddleware.asyncHandler(studyController.controlStudyCreate),
 );
-
-/* 오늘의 습관 */
-
-/* 오늘의 집증 */
-
-/* 유저 기능 */
 
 // // 예시 API 엔드포인트
 // router.get(

--- a/src/api/routes/study.routes.js
+++ b/src/api/routes/study.routes.js
@@ -14,8 +14,21 @@ const router = express.Router();
 router.use(corsMiddleware); // CORS 미들웨어 적용
 router.use(express.json());
 
+/* 스터디 */
 // 스터디 목록 조회 API 엔드포인트
 router.get('/', errorMiddleware.asyncHandler(studyController.controlStudyList));
+
+// 스터디 생성 API 엔드포인트
+router.post(
+  '/',
+  errorMiddleware.asyncHandler(studyController.controlStudyCreate),
+);
+
+/* 오늘의 습관 */
+
+/* 오늘의 집증 */
+
+/* 유저 기능 */
 
 // // 예시 API 엔드포인트
 // router.get(

--- a/src/api/routes/study.routes.js
+++ b/src/api/routes/study.routes.js
@@ -12,7 +12,6 @@ import studyController from '../controllers/study.controllers.js';
 const router = express.Router();
 
 router.use(corsMiddleware); // CORS 미들웨어 적용
-router.use(express.json({ limit: '1mb' }));
 
 // 스터디 목록 조회 API 엔드포인트
 router.get('/', errorMiddleware.asyncHandler(studyController.controlStudyList));

--- a/src/api/routes/user.routes.js
+++ b/src/api/routes/user.routes.js
@@ -30,7 +30,6 @@
 // const router = express.Router();
 //
 // router.use(coreMiddleware); // CORS 미들웨어 적용
-// router.use(express.json());
 //
 // // 예시 API 엔드포인트
 // router.get(

--- a/src/api/services/study.services.js
+++ b/src/api/services/study.services.js
@@ -61,4 +61,24 @@ async function serviceStudyList(options) {
   }
 }
 
-export default { serviceStudyList };
+async function serviceStudyCreate(
+  nick,
+  name,
+  content,
+  img,
+  password,
+  isActive,
+) {
+  try {
+    const studyCreate = await prisma.study.create({
+      data: { nick, name, content, img, password, isActive },
+    });
+
+    return studyCreate;
+  } catch (error) {
+    console.log(error, '가 발생했습니다.');
+    throw error;
+  }
+}
+
+export default { serviceStudyList, serviceStudyCreate };

--- a/src/api/services/study.services.js
+++ b/src/api/services/study.services.js
@@ -66,12 +66,22 @@ async function serviceStudyCreate(
   name,
   content,
   img,
-  password,
+  passwordHash,
   isActive,
 ) {
   try {
     const studyCreate = await prisma.study.create({
-      data: { nick, name, content, img, password, isActive },
+      data: { nick, name, content, img, password: passwordHash, isActive },
+      select: {
+        id: true,
+        nick: true,
+        name: true,
+        content: true,
+        img: true,
+        isActive: true,
+        createdAt: true,
+        updatedAt: true,
+      },
     });
 
     return studyCreate;

--- a/src/api/structs.js
+++ b/src/api/structs.js
@@ -3,11 +3,11 @@ import * as s from 'superstruct';
 export const createStudy = s.object({
   nick: s.size(s.string(), 1, 30),
   name: s.size(s.string(), 1, 100),
-  content: s.string(),
-  img: s.string(),
-  password: s.string(),
-  checkPassword: s.string(),
-  isActive: s.boolean(),
+  content: s.size(s.string(), 0, 2000), // 본문 상한
+  img: s.pattern(s.string(), /^\/img\/[a-z0-9\-_.]+\.png$/i), // 허용 경로/확장자
+  password: s.size(s.string(), 1, 64),
+  checkPassword: s.size(s.string(), 1, 64),
+  isActive: s.defaulted(s.boolean(), true), // 기본값 부여
 });
 
 export const patchStudy = s.partial(createStudy);

--- a/src/api/structs.js
+++ b/src/api/structs.js
@@ -1,0 +1,13 @@
+import * as s from 'superstruct';
+
+export const createStudy = s.object({
+  nick: s.size(s.string(), 1, 30),
+  name: s.size(s.string(), 1, 100),
+  content: s.string(),
+  img: s.string(),
+  password: s.string(),
+  checkPassword: s.string(),
+  isActive: s.boolean(),
+});
+
+export const patchStudy = s.partial(createStudy);

--- a/src/app.js
+++ b/src/app.js
@@ -22,10 +22,9 @@ if (!process.env.DATABASE_URL) {
   }
 }
 
-
 const app = express();
 
-app.use(express.json()); // JSON 파싱 미들웨어 추가
+app.use(express.json({ limit: '1mb' })); // JSON 파싱 미들웨어 추가
 app.use(morgan('combined'));
 app.use('/study', studyRoutes);
 

--- a/src/app.js
+++ b/src/app.js
@@ -25,6 +25,7 @@ if (!process.env.DATABASE_URL) {
 const app = express();
 
 app.use(express.json({ limit: '1mb' })); // JSON 파싱 미들웨어 추가
+app.use(express.urlencoded({ limit: '1mb', extended: true }));
 app.use(morgan('combined'));
 app.use('/study', studyRoutes);
 

--- a/src/common/error.js
+++ b/src/common/error.js
@@ -92,7 +92,12 @@ function errorHandler(err, req, res, next) {
     err.code = 'PRISMA_RUST_PANIC';
     err.message = 'Database engine panic';
   }
-
+  // Superstruct 에러 처리
+  else if (err.name === 'StructError') {
+    err.status = 400;
+    err.code = 'INVALID_INPUT';
+    err.message = 'Invalid input data';
+  }
   // JWT 에러 처리
   else if (err.name === 'JsonWebTokenError') {
     err.status = 401;

--- a/src/common/error.js
+++ b/src/common/error.js
@@ -97,6 +97,22 @@ function errorHandler(err, req, res, next) {
     err.status = 400;
     err.code = 'INVALID_INPUT';
     err.message = 'Invalid input data';
+    try {
+      const failures =
+        typeof err.failures === 'function' ? Array.from(err.failures()) : [];
+      err.details = {
+        fields: failures.map(f => ({
+          path:
+            Array.isArray(f.path) && f.path.length
+              ? f.path.join('.')
+              : (f.key ?? ''),
+          type: f.type,
+          message: f.message,
+        })),
+      };
+    } catch (_) {
+      // noop: details는 선택 항목
+    }
   }
   // JWT 에러 처리
   else if (err.name === 'JsonWebTokenError') {


### PR DESCRIPTION
- 닉네임, 스터디 이름, 스터디에 대한 간단한 소개, 배경 선택, 비밀번호(해시 값 저장) 및 비밀번호 확인을 입력하여 스터디를 생성
- http 파일을 이용하여, DB에 저장이 되는 것을 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 스터디 생성 API(POST /study) 추가: nick, name, content, img, password, checkPassword, isActive 본문 지원. 성공 시 201 응답과 생성된 스터디 정보 및 Location 헤더 반환.
- 문서
  - GET/POST /study 요청 샘플 추가로 사용 예시 보강(요청 포맷 및 샘플 페이로드 포함).
- 기타
  - 요청 본문 크기 제한(1MB) 적용 및 URL-encoded 파서 추가.
  - 입력 유효성 검사 강화 및 실패 시 구조화된 400 응답(Invalid input data) 제공.
  - 비밀번호 해시 저장 및 개발·운영 의존성 추가.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->