### PR TITLE
feat: Study 삭제 API 추가

### DIFF
--- a/http/study.http
+++ b/http/study.http
@@ -18,3 +18,7 @@ Content-Type: application/json
     "checkPassword": "1234",
     "isActive": true
 }
+
+###
+
+DELETE http://localhost:3000/study/16?password=1234

--- a/http/study.http
+++ b/http/study.http
@@ -21,4 +21,9 @@ Content-Type: application/json
 
 ###
 
-DELETE http://localhost:3000/study/16?password=1234
+DELETE http://localhost:3000/study/16
+Content-Type: application/json
+
+{
+  "password": "1234"
+}

--- a/src/api/controllers/study.controllers.js
+++ b/src/api/controllers/study.controllers.js
@@ -25,7 +25,7 @@ async function controlStudyList(req, res) {
   const pointOrder = pointOrderRaw === 'desc' ? 'desc' : 'asc';
   const recentOrder = recentOrderRaw === 'old' ? 'old' : 'recent';
 
-  // 서비스 호출
+  /* 서비스 호출 */
   const studyList = await studyService.serviceStudyList({
     offset,
     limit,
@@ -34,11 +34,12 @@ async function controlStudyList(req, res) {
     recentOrder,
   });
 
+  /* 결과 반환 */
   res.json(studyList);
 }
 
 async function controlStudyCreate(req, res) {
-  /* 입력 검증 */
+  /* 쿼리 파라미터 파싱 및 입력 검증 */
   assert(req.body, createStudy);
   const { nick, name, content, img, password, checkPassword, isActive } =
     req.body;
@@ -49,6 +50,7 @@ async function controlStudyCreate(req, res) {
     throw err;
   }
   const passwordHash = await argon2.hash(password);
+
   /* 서비스 호출 */
   const studyCreate = await studyService.serviceStudyCreate(
     nick,
@@ -63,4 +65,24 @@ async function controlStudyCreate(req, res) {
   res.status(201).location(`/study/${studyCreate.id}`).json(studyCreate);
 }
 
-export default { controlStudyList, controlStudyCreate };
+async function controlStudyDelete(req, res) {
+  /* 쿼리 파라미터 파싱 및 입력 검증 */
+  const studyId = Number.parseInt(req.params.studyId, 10);
+  if (!Number.isFinite(studyId) || studyId <= 0) {
+    const err = new Error('유효하지 않은 스터디 ID입니다.');
+    err.status = 400;
+    err.code = 'INVALID_STUDY_ID';
+    throw err;
+  }
+
+  /* 서비스 호출 */
+  const studyDelete = await studyService.serviceStudyDelete(
+    studyId,
+    req.query.password,
+  );
+
+  /* 결과 반환 */
+  res.status(201).json(studyDelete);
+}
+
+export default { controlStudyList, controlStudyCreate, controlStudyDelete };

--- a/src/api/controllers/study.controllers.js
+++ b/src/api/controllers/study.controllers.js
@@ -75,14 +75,19 @@ async function controlStudyDelete(req, res) {
     throw err;
   }
 
+  const password = req.body.password;
+  if (typeof password !== 'string' || password.length === 0) {
+    const err = new Error('비밀번호가 누락되었습니다.');
+    err.status = 400;
+    err.code = 'PASSWORD_REQUIRED';
+    throw err;
+  }
+
   /* 서비스 호출 */
-  const studyDelete = await studyService.serviceStudyDelete(
-    studyId,
-    req.query.password,
-  );
+  await studyService.serviceStudyDelete(studyId, password);
 
   /* 결과 반환 */
-  res.status(201).json(studyDelete);
+  res.status(204).end();
 }
 
 export default { controlStudyList, controlStudyCreate, controlStudyDelete };

--- a/src/api/routes/study.routes.js
+++ b/src/api/routes/study.routes.js
@@ -22,6 +22,12 @@ router.post(
   errorMiddleware.asyncHandler(studyController.controlStudyCreate),
 );
 
+// 스터디 삭제 API 엔드포인트
+router.delete(
+  '/:studyId',
+  errorMiddleware.asyncHandler(studyController.controlStudyDelete),
+);
+
 // // 예시 API 엔드포인트
 // router.get(
 //   '/example-API',

--- a/src/api/services/study.services.js
+++ b/src/api/services/study.services.js
@@ -105,6 +105,13 @@ async function serviceStudyDelete(studyId, password) {
       throw err;
     }
 
+    if (!password) {
+      const err = new Error('비밀번호가 누락되었습니다.');
+      err.status = 400;
+      err.code = 'PASSWORD_REQUIRED';
+      throw err;
+    }
+
     const isPasswordValid = await argon2.verify(study.password, password);
     if (!isPasswordValid) {
       const err = new Error('비밀번호가 일치하지 않습니다.');

--- a/src/api/services/study.services.js
+++ b/src/api/services/study.services.js
@@ -1,6 +1,7 @@
 // 비즈니스 로직의 핵심(도메인 규칙, 트랜잭션, 외부 API 연동)
 // 데이터 접근 계층 호출(Prisma/Mongoose/Raw SQL)
 import { PrismaClient } from '@prisma/client';
+import argon2 from 'argon2';
 
 const prisma = new PrismaClient();
 
@@ -91,4 +92,34 @@ async function serviceStudyCreate(
   }
 }
 
-export default { serviceStudyList, serviceStudyCreate };
+async function serviceStudyDelete(studyId, password) {
+  try {
+    const study = await prisma.study.findUnique({
+      where: { id: studyId },
+      select: { password: true },
+    });
+    if (!study) {
+      const err = new Error('존재하지 않는 스터디 ID입니다.');
+      err.status = 404;
+      err.code = 'STUDY_NOT_FOUND';
+      throw err;
+    }
+
+    const isPasswordValid = await argon2.verify(study.password, password);
+    if (!isPasswordValid) {
+      const err = new Error('비밀번호가 일치하지 않습니다.');
+      err.status = 403;
+      err.code = 'INVALID_PASSWORD';
+      throw err;
+    }
+
+    await prisma.study.delete({ where: { id: studyId } });
+
+    return { message: '스터디가 성공적으로 삭제되었습니다.' };
+  } catch (error) {
+    console.log(error, '가 발생했습니다.');
+    throw error;
+  }
+}
+
+export default { serviceStudyList, serviceStudyCreate, serviceStudyDelete };

--- a/src/api/structs.js
+++ b/src/api/structs.js
@@ -4,7 +4,7 @@ export const createStudy = s.object({
   nick: s.size(s.string(), 1, 30),
   name: s.size(s.string(), 1, 100),
   content: s.size(s.string(), 0, 2000), // 본문 상한
-  img: s.pattern(s.string(), /^\/img\/[a-z0-9\-_.]+\.png$/i), // 허용 경로/확장자
+  img: s.string(), // 허용 경로/확장자
   password: s.size(s.string(), 1, 64),
   checkPassword: s.size(s.string(), 1, 64),
   isActive: s.defaulted(s.boolean(), true), // 기본값 부여


### PR DESCRIPTION
- 비밀번호를 URL 쿼리로 Study ID를 URL 파라미터로 받습니다.
- 스터디 등록 시 입력했던 비밀번호와 일치할 경우, Study ID에 해당하는 스터디 삭제합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 스터디 삭제 기능 추가: 비밀번호 검증 후 스터디를 삭제할 수 있으며, 성공 시 삭제 완료(204)를 반환합니다.

- 유효성/오류 처리 강화
  - 존재하지 않는 스터디에 대해 404, 비밀번호 불일치에 403, 잘못된 ID나 누락된 비밀번호에 400을 반환합니다.

- 문서
  - 삭제 요청 예시 업데이트: 비밀번호는 쿼리 파라미터가 아닌 JSON 요청 본문으로 전달합니다.

- 기타
  - 이미지 필드 유효성 제약 완화(경로/확장자 제한 제거).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->