### PR TITLE
feat : 오늘의습관 생성 및 체크 API 구현

### DIFF
--- a/http/habit.http
+++ b/http/habit.http
@@ -1,1 +1,27 @@
 # 오늘의 습관 API를 테스트하는 HTTP 요청 파일입니다.
+// 로컬 시드 데이터를 기준으로 테스트 http 요청
+@base = http://localhost:3000/api
+@studyId = 2
+@pwd = '패스워드'
+@date = 2025-09-02
+
+### 1) 오늘의 습관 조회 (지금 해본 것)
+GET {{base}}/habits/today/{{studyId}}
+x-study-password: {{pwd}}
+
+### 2) 오늘의 습관 생성 (여기서 실제 생성됨)
+POST {{base}}/habits/today/{{studyId}}
+Content-Type: application/json
+x-study-password: {{pwd}}
+
+{
+  "habits": ["물 1리터 마시기", "운동 30분", "회고 쓰기"]
+}
+
+### 3) 체크/해제 (토글) — 생성 후 응답/조회에서 받은 habitId로 바꿔서 실행
+PATCH {{base}}/habits/1/toggle
+x-study-password: {{pwd}}
+
+### 4) 주간 기록 조회 (해당 날짜가 속한 주)
+GET {{base}}/habits/week/{{studyId}}?date={{date}}
+x-study-password: {{pwd}}

--- a/http/habit.http
+++ b/http/habit.http
@@ -2,7 +2,7 @@
 // 로컬 시드 데이터를 기준으로 테스트 http 요청
 @base = http://localhost:3000/api
 @studyId = 2
-@pwd = '패스워드'
+@pwd = test
 @date = 2025-09-02
 
 ### 1) 오늘의 습관 조회 (지금 해본 것)

--- a/src/api/controllers/habit.controllers.js
+++ b/src/api/controllers/habit.controllers.js
@@ -1,3 +1,4 @@
+// src/api/controllers/habit.controllers.js
 // 요청 파싱(params/query) + 입력 검증 + 서비스 호출 + 에러 변환
 
 import getTodayHabitsService, {
@@ -6,7 +7,7 @@ import getTodayHabitsService, {
   getWeekHabitsService,
 } from '../services/habit.services.js';
 
-/*오늘의 습관 조회 */
+/* 오늘의 습관 조회 */
 async function getTodayHabitsController(req, res, next) {
   try {
     const studyIdStr = req.params.studyId;
@@ -33,6 +34,7 @@ async function getTodayHabitsController(req, res, next) {
     if (!password) {
       return res.status(400).json({ message: '비밀번호가 필요합니다.' });
     }
+
     const data = await getTodayHabitsService({ studyId, password });
     res.set('Cache-Control', 'no-store');
     res.vary('x-study-password');
@@ -48,7 +50,7 @@ async function getTodayHabitsController(req, res, next) {
   }
 }
 
-/*오늘의 습관 생성 (배열로 들어온 title들을 오늘 날짜로 생성)*/
+/* 오늘의 습관 생성 (배열로 들어온 title들을 오늘 날짜로 생성) */
 async function createTodayHabitsController(req, res, next) {
   try {
     const studyIdStr = req.params.studyId;
@@ -58,6 +60,11 @@ async function createTodayHabitsController(req, res, next) {
         .json({ message: 'studyId는 1 이상의 정수여야 합니다.' });
     }
     const studyId = Number.parseInt(studyIdStr, 10);
+    if (studyId <= 0) {
+      return res
+        .status(400)
+        .json({ message: 'studyId는 1 이상의 정수여야 합니다.' });
+    }
 
     const headerPwd = req.get('x-study-password');
     const bodyPwd =
@@ -67,6 +74,11 @@ async function createTodayHabitsController(req, res, next) {
         ? headerPwd
         : bodyPwd;
 
+    if (!password) {
+      return res.status(400).json({ message: '비밀번호가 필요합니다.' });
+    }
+
+    // 입력 정규화: habits(string[]) 또는 items[{title}]
     let titles = [];
     if (Array.isArray(req.body?.habits)) {
       titles = req.body.habits.filter(
@@ -105,8 +117,7 @@ async function createTodayHabitsController(req, res, next) {
   }
 }
 
-/** 오늘의 습관 체크/해제 (토글) */
-
+/* 오늘의 습관 체크/해제 (토글) */
 async function toggleHabitController(req, res, next) {
   try {
     const habitIdStr = req.params.habitId;
@@ -116,6 +127,11 @@ async function toggleHabitController(req, res, next) {
         .json({ message: 'habitId는 1 이상의 정수여야 합니다.' });
     }
     const habitId = Number.parseInt(habitIdStr, 10);
+    if (habitId <= 0) {
+      return res
+        .status(400)
+        .json({ message: 'habitId는 1 이상의 정수여야 합니다.' });
+    }
 
     const headerPwd = req.get('x-study-password');
     const bodyPwd =
@@ -124,6 +140,10 @@ async function toggleHabitController(req, res, next) {
       typeof headerPwd === 'string' && headerPwd.length > 0
         ? headerPwd
         : bodyPwd;
+
+    if (!password) {
+      return res.status(400).json({ message: '비밀번호가 필요합니다.' });
+    }
 
     const data = await toggleHabitService({ habitId, password });
     res.set('Cache-Control', 'no-store');
@@ -140,8 +160,7 @@ async function toggleHabitController(req, res, next) {
   }
 }
 
-/* 주간 습관 기록 조회*/
-
+/* 주간 습관 기록 조회 */
 async function getWeekHabitsController(req, res, next) {
   try {
     const studyIdStr = req.params.studyId;
@@ -151,6 +170,11 @@ async function getWeekHabitsController(req, res, next) {
         .json({ message: 'studyId는 1 이상의 정수여야 합니다.' });
     }
     const studyId = Number.parseInt(studyIdStr, 10);
+    if (studyId <= 0) {
+      return res
+        .status(400)
+        .json({ message: 'studyId는 1 이상의 정수여야 합니다.' });
+    }
 
     const headerPwd = req.get('x-study-password');
     const bodyPwd =
@@ -159,6 +183,10 @@ async function getWeekHabitsController(req, res, next) {
       typeof headerPwd === 'string' && headerPwd.length > 0
         ? headerPwd
         : bodyPwd;
+
+    if (!password) {
+      return res.status(400).json({ message: '비밀번호가 필요합니다.' });
+    }
 
     const dateStr =
       typeof req.query?.date === 'string' ? req.query.date : undefined;

--- a/src/api/controllers/habit.controllers.js
+++ b/src/api/controllers/habit.controllers.js
@@ -1,7 +1,12 @@
 // 요청 파싱(params/query) + 입력 검증 + 서비스 호출 + 에러 변환
 
-import getTodayHabitsService from '../services/habit.services.js';
+import getTodayHabitsService, {
+  createTodayHabitsService,
+  toggleHabitService,
+  getWeekHabitsService,
+} from '../services/habit.services.js';
 
+/*오늘의 습관 조회 */
 async function getTodayHabitsController(req, res, next) {
   try {
     const studyIdStr = req.params.studyId;
@@ -42,5 +47,147 @@ async function getTodayHabitsController(req, res, next) {
     return next(err);
   }
 }
-export { getTodayHabitsController };
-export default { getTodayHabitsController };
+
+/*오늘의 습관 생성 (배열로 들어온 title들을 오늘 날짜로 생성)*/
+async function createTodayHabitsController(req, res, next) {
+  try {
+    const studyIdStr = req.params.studyId;
+    if (!/^\d+$/.test(studyIdStr)) {
+      return res
+        .status(400)
+        .json({ message: 'studyId는 1 이상의 정수여야 합니다.' });
+    }
+    const studyId = Number.parseInt(studyIdStr, 10);
+
+    const headerPwd = req.get('x-study-password');
+    const bodyPwd =
+      typeof req.body?.password === 'string' ? req.body.password : undefined;
+    const password =
+      typeof headerPwd === 'string' && headerPwd.length > 0
+        ? headerPwd
+        : bodyPwd;
+
+    let titles = [];
+    if (Array.isArray(req.body?.habits)) {
+      titles = req.body.habits.filter(
+        x => typeof x === 'string' && x.trim().length > 0,
+      );
+    } else if (Array.isArray(req.body?.items)) {
+      titles = req.body.items
+        .map(it => (typeof it?.title === 'string' ? it.title : ''))
+        .filter(x => x.trim().length > 0);
+    }
+
+    if (!titles.length) {
+      return res.status(400).json({
+        message: '생성할 습관 목록(habits 또는 items.title)이 필요합니다.',
+      });
+    }
+
+    const data = await createTodayHabitsService({ studyId, password, titles });
+    res.set('Cache-Control', 'no-store');
+    res.vary('x-study-password');
+    return res.status(201).json(data);
+  } catch (err) {
+    if (err.name === 'UnauthorizedError') {
+      return res.status(401).json({ message: err.message });
+    }
+    if (err.code === 'P2002') {
+      // Prisma unique 에러(동일 항목 일부 중복)
+      return res
+        .status(409)
+        .json({ message: '일부 습관은 이미 오늘 생성되어 있습니다.' });
+    }
+    if (err.name === 'NotFoundError') {
+      return res.status(404).json({ message: err.message });
+    }
+    return next(err);
+  }
+}
+
+/** 오늘의 습관 체크/해제 (토글) */
+
+async function toggleHabitController(req, res, next) {
+  try {
+    const habitIdStr = req.params.habitId;
+    if (!/^\d+$/.test(habitIdStr)) {
+      return res
+        .status(400)
+        .json({ message: 'habitId는 1 이상의 정수여야 합니다.' });
+    }
+    const habitId = Number.parseInt(habitIdStr, 10);
+
+    const headerPwd = req.get('x-study-password');
+    const bodyPwd =
+      typeof req.body?.password === 'string' ? req.body.password : undefined;
+    const password =
+      typeof headerPwd === 'string' && headerPwd.length > 0
+        ? headerPwd
+        : bodyPwd;
+
+    const data = await toggleHabitService({ habitId, password });
+    res.set('Cache-Control', 'no-store');
+    res.vary('x-study-password');
+    return res.json(data);
+  } catch (err) {
+    if (err.name === 'UnauthorizedError') {
+      return res.status(401).json({ message: err.message });
+    }
+    if (err.name === 'NotFoundError') {
+      return res.status(404).json({ message: err.message });
+    }
+    return next(err);
+  }
+}
+
+/* 주간 습관 기록 조회*/
+
+async function getWeekHabitsController(req, res, next) {
+  try {
+    const studyIdStr = req.params.studyId;
+    if (!/^\d+$/.test(studyIdStr)) {
+      return res
+        .status(400)
+        .json({ message: 'studyId는 1 이상의 정수여야 합니다.' });
+    }
+    const studyId = Number.parseInt(studyIdStr, 10);
+
+    const headerPwd = req.get('x-study-password');
+    const bodyPwd =
+      typeof req.body?.password === 'string' ? req.body.password : undefined;
+    const password =
+      typeof headerPwd === 'string' && headerPwd.length > 0
+        ? headerPwd
+        : bodyPwd;
+
+    const dateStr =
+      typeof req.query?.date === 'string' ? req.query.date : undefined;
+
+    const data = await getWeekHabitsService({ studyId, password, dateStr });
+    res.set('Cache-Control', 'no-store');
+    res.vary('x-study-password');
+    return res.json(data);
+  } catch (err) {
+    if (err.name === 'UnauthorizedError') {
+      return res.status(401).json({ message: err.message });
+    }
+    if (err.name === 'NotFoundError') {
+      return res.status(404).json({ message: err.message });
+    }
+    return next(err);
+  }
+}
+
+export {
+  getTodayHabitsController,
+  createTodayHabitsController,
+  toggleHabitController,
+  getWeekHabitsController,
+};
+
+export default {
+  getTodayHabitsController,
+  createTodayHabitsController,
+  toggleHabitController,
+  getWeekHabitsController,
+};

--- a/src/api/routes/habit.routes.js
+++ b/src/api/routes/habit.routes.js
@@ -1,24 +1,46 @@
 // Description: 습관(Habit) 관련 API 라우터 설정 파일입니다.
 
-// 라이브러리 정의
 import express from 'express';
-// 미들웨어 정의
 import corsMiddleware from '../../common/cors.js';
 
-// 컨트롤러 정의 (오늘의 습관 조회)
-import { asyncHandler, errorHandler } from '../../common/error.js'; // 에러 케이스 추가는 여기서 관리
-import { getTodayHabitsController } from '../controllers/habit.controllers.js';
+// 컨트롤러
+import errorMiddleware from '../../common/error.js'; // 에러 케이스 추가는 여기서 관리
+import {
+  getTodayHabitsController,
+  createTodayHabitsController,
+  toggleHabitController,
+  getWeekHabitsController,
+} from '../controllers/habit.controllers.js';
 
 const router = express.Router();
 
 router.use(corsMiddleware); // CORS 미들웨어 적용
 
-// 오늘의 습관 조회 API
-router.get('/habits/today/:studyId', asyncHandler(getTodayHabitsController));
+// 오늘의 습관 조회
+router.get(
+  '/habits/today/:studyId',
+  errorMiddleware.asyncHandler(getTodayHabitsController),
+);
 
-// (필요 시 여기에 다른 habit 관련 엔드포인트를 추가)
+// 오늘의 습관 생성
+router.post(
+  '/habits/today/:studyId',
+  errorMiddleware.asyncHandler(createTodayHabitsController),
+);
+
+// 오늘의 습관 체크/해제 (토글)
+router.patch(
+  '/habits/:habitId/toggle',
+  errorMiddleware.asyncHandler(toggleHabitController),
+);
+
+// 주간 습관 기록 조회 (?date=YYYY-MM-DD)
+router.get(
+  '/habits/week/:studyId',
+  errorMiddleware.asyncHandler(getWeekHabitsController),
+);
 
 // 에러 핸들링 미들웨어 (맨 마지막)
-router.use(errorHandler);
+router.use(errorMiddleware.errorHandler);
 
 export default router;

--- a/src/api/services/habit.services.js
+++ b/src/api/services/habit.services.js
@@ -2,7 +2,6 @@
 // 데이터 접근 계층 호출(Prisma/Mongoose/Raw SQL)
 
 import { PrismaClient } from '@prisma/client';
-import bcrypt from 'bcryptjs';
 import argon2 from 'argon2';
 
 const prisma = new PrismaClient();
@@ -37,8 +36,44 @@ function getKSTDayRange(now = new Date()) {
   return { startUtc, endUtc, nowKstIso, kstDateStr };
 }
 
-export default async function getTodayHabitsService({ studyId, password }) {
-  // 1) 스터디 확인
+/**
+ * 주 시작일(월요일 00:00 KST)의 UTC Date 반환 + 주 끝(일요일 24:00 직전)
+ */
+function getKSTWeekRange(dateInput) {
+  const base = dateInput ? new Date(dateInput) : new Date();
+  const baseKst = new Date(base.getTime() + 9 * 3600000);
+
+  const day = baseKst.getUTCDay();
+
+  const diffToMon = (day + 6) % 7;
+  const monKstUTC = Date.UTC(
+    baseKst.getUTCFullYear(),
+    baseKst.getUTCMonth(),
+    baseKst.getUTCDate() - diffToMon,
+    0,
+    0,
+    0,
+    0,
+  );
+  const monUtc = new Date(monKstUTC - 9 * 3600000);
+  const sunUtcEnd = new Date(monUtc.getTime() + 7 * 24 * 3600000);
+  const weekDateOnly = new Date(monUtc); // HabitHistory.weekDate용(날짜 컬럼이면 날짜만 사용)
+
+  const yyyy = String(baseKst.getUTCFullYear());
+  const mm = String(baseKst.getUTCMonth() + 1).padStart(2, '0');
+  const dd = String(baseKst.getUTCDate()).padStart(2, '0');
+  const kstDateStr = `${yyyy}-${mm}-${dd}`;
+
+  return {
+    weekStartUtc: monUtc, // 포함
+    weekEndUtc: sunUtcEnd, // 미포함
+    weekDateOnly, // HabitHistory.weekDate용
+    kstDateStr, // 요청 기준 일자(문자열)
+  };
+}
+
+/* 스터디 + 비밀번호 검증 (argon2/평문 seed 지원) */
+async function assertStudyWithPassword({ studyId, password }) {
   const study = await prisma.study.findUnique({
     where: { id: studyId },
     select: { id: true, name: true, password: true, isActive: true },
@@ -48,8 +83,6 @@ export default async function getTodayHabitsService({ studyId, password }) {
     e.name = 'NotFoundError';
     throw e;
   }
-
-  // 2) 비밀번호 검증
   if (!password || !study.password) {
     const e = new Error('비밀번호가 필요합니다.');
     e.name = 'UnauthorizedError';
@@ -61,13 +94,11 @@ export default async function getTodayHabitsService({ studyId, password }) {
   try {
     if (typeof hash === 'string' && hash.startsWith('$argon2')) {
       ok = await argon2.verify(hash, password);
-    } else if (typeof hash === 'string' && /^\$2[aby]\$/.test(hash)) {
-      ok = await bcrypt.compare(password, hash);
     } else {
       // seed 등 평문 대비
       ok = password === hash;
     }
-  } catch (_) {
+  } catch {
     ok = false;
   }
 
@@ -77,10 +108,18 @@ export default async function getTodayHabitsService({ studyId, password }) {
     throw e;
   }
 
-  // 3) 오늘 범위 계산
+  return study;
+}
+
+/* GET 오늘의 습관 조회 */
+export default async function getTodayHabitsService({ studyId, password }) {
+  // 1) 인증
+  const study = await assertStudyWithPassword({ studyId, password });
+
+  // 2) 오늘 범위 계산
   const { startUtc, endUtc, nowKstIso, kstDateStr } = getKSTDayRange();
 
-  // 4) 오늘의 Habit 조회
+  // 3) 오늘 습관 조회
   const habits = await prisma.habit.findMany({
     where: {
       date: { gte: startUtc, lt: endUtc },
@@ -112,5 +151,212 @@ export default async function getTodayHabitsService({ studyId, password }) {
       focusToday: `/studies/${studyId}/focus-today`,
       home: `/studies/${studyId}`,
     },
+  };
+}
+
+/* POST 오늘의 습관 생성 */
+export async function createTodayHabitsService({ studyId, password, titles }) {
+  const study = await assertStudyWithPassword({ studyId, password });
+
+  const { startUtc, endUtc, nowKstIso, kstDateStr } = getKSTDayRange();
+  const { weekStartUtc, weekDateOnly } = getKSTWeekRange(startUtc);
+
+  // 1) 해당 주 HabitHistory upsert
+  const hh = await prisma.habitHistory.upsert({
+    where: { studyId_weekDate: { studyId, weekDate: weekDateOnly } },
+    update: {},
+    create: {
+      studyId,
+      weekDate: weekDateOnly,
+    },
+    select: { id: true },
+  });
+
+  // 2) 오늘 날짜에 대해 타이틀들 생성 (중복은 unique 제약으로 스킵)
+  const dataToCreate = titles.map(title => ({
+    habit: title.trim(),
+    date: startUtc, // 00:00 UTC 환산 기준(오늘)
+    isDone: false,
+    habitHistoryId: hh.id,
+  }));
+
+  // createMany는 unique 충돌 시 skipDuplicates 사용
+  const createRes = await prisma.habit.createMany({
+    data: dataToCreate,
+    skipDuplicates: true,
+  });
+
+  // 3) 오늘 생성/전체 목록 반환
+  const habits = await prisma.habit.findMany({
+    where: {
+      date: { gte: startUtc, lt: endUtc },
+      habitHistoryId: hh.id,
+    },
+    orderBy: [{ createdAt: 'asc' }, { id: 'asc' }],
+  });
+
+  return {
+    study: { id: study.id, name: study.name, isActive: study.isActive },
+    now: nowKstIso,
+    date: kstDateStr,
+    createdCount: createRes.count,
+    habits: habits.map(h => ({
+      habitId: h.id,
+      title: h.habit,
+      isDone: h.isDone,
+      date: h.date,
+      habitHistoryId: h.habitHistoryId,
+    })),
+  };
+}
+
+/* PATCH 오늘의 습관 체크/해제 (토글) */
+export async function toggleHabitService({ habitId, password }) {
+  // habit + history + study로 따라 들어가 비밀번호 검증
+  const target = await prisma.habit.findUnique({
+    where: { id: habitId },
+    select: {
+      id: true,
+      isDone: true,
+      date: true,
+      habitHistoryId: true,
+      habitHistory: {
+        select: {
+          id: true,
+          studyId: true,
+          weekDate: true,
+        },
+      },
+    },
+  });
+
+  if (!target) {
+    const e = new Error('해당 습관이 존재하지 않습니다.');
+    e.name = 'NotFoundError';
+    throw e;
+  }
+
+  // 스터디 인증
+  await assertStudyWithPassword({
+    studyId: target.habitHistory.studyId,
+    password,
+  });
+
+  // 토글
+  const updated = await prisma.habit.update({
+    where: { id: habitId },
+    data: { isDone: !target.isDone },
+    select: { id: true, isDone: true, date: true, habitHistoryId: true },
+  });
+
+  // KST 기준 오늘 날짜 문자열을 만들어 day-of-week 판정
+  const kRange = getKSTDayRange(updated.date);
+  const dayHabits = await prisma.habit.findMany({
+    where: {
+      habitHistoryId: updated.habitHistoryId,
+      date: { gte: kRange.startUtc, lt: kRange.endUtc },
+    },
+    select: { isDone: true },
+  });
+  const anyDone = dayHabits.some(h => h.isDone);
+
+  // KST 기준 요일: 0=일 ~ 6=토
+  const kst = new Date(updated.date.getTime() + 9 * 3600000);
+  const dow = kst.getUTCDay();
+
+  const dayFieldMap = {
+    1: 'monDone',
+    2: 'tueDone',
+    3: 'wedDone',
+    4: 'thuDone',
+    5: 'friDone',
+    6: 'satDone',
+    0: 'sunDone',
+  };
+  const field = dayFieldMap[dow];
+
+  await prisma.habitHistory.update({
+    where: { id: updated.habitHistoryId },
+    data: { [field]: anyDone },
+  });
+
+  return {
+    habitId: updated.id,
+    isDone: updated.isDone,
+    date: updated.date,
+    habitHistoryId: updated.habitHistoryId,
+  };
+}
+
+/** GET 주간 습관 기록 조회 */
+export async function getWeekHabitsService({ studyId, password, dateStr }) {
+  const study = await assertStudyWithPassword({ studyId, password });
+
+  const { weekStartUtc, weekEndUtc, weekDateOnly } = getKSTWeekRange(dateStr);
+
+  const history = await prisma.habitHistory.findUnique({
+    where: { studyId_weekDate: { studyId, weekDate: weekDateOnly } },
+    select: {
+      id: true,
+      monDone: true,
+      tueDone: true,
+      wedDone: true,
+      thuDone: true,
+      friDone: true,
+      satDone: true,
+      sunDone: true,
+    },
+  });
+
+  // 해당 주에 단 한 번도 오늘의 습관 생성이 없었다면 history가 없을 수 있음
+  const habits = await prisma.habit.findMany({
+    where: {
+      date: { gte: weekStartUtc, lt: weekEndUtc },
+      habitHistory: { is: { studyId } },
+    },
+    orderBy: [{ date: 'asc' }, { createdAt: 'asc' }, { id: 'asc' }],
+  });
+
+  // 응답용: 날짜별 → [ {habitId, title, isDone} ]
+  const days = {};
+  for (let i = 0; i < 7; i++) {
+    const d = new Date(weekStartUtc.getTime() + i * 24 * 3600000);
+    days[d.toISOString().slice(0, 10)] = [];
+  }
+  habits.forEach(h => {
+    const ymd = new Date(h.date.getTime() + 9 * 3600000) // to KST
+      .toISOString()
+      .slice(0, 10);
+    if (!days[ymd]) days[ymd] = [];
+    days[ymd].push({
+      habitId: h.id,
+      title: h.habit,
+      isDone: h.isDone,
+    });
+  });
+
+  return {
+    study: { id: study.id, name: study.name, isActive: study.isActive },
+    week: {
+      start: new Date(weekStartUtc.getTime() + 9 * 3600000)
+        .toISOString()
+        .slice(0, 10),
+      end: new Date(weekEndUtc.getTime() - 1 + 9 * 3600000)
+        .toISOString()
+        .slice(0, 10),
+      weekDate: weekDateOnly, // HabitHistory.weekDate
+      summary: history
+        ? {
+            monDone: history.monDone,
+            tueDone: history.tueDone,
+            wedDone: history.wedDone,
+            thuDone: history.thuDone,
+            friDone: history.friDone,
+            satDone: history.satDone,
+            sunDone: history.sunDone,
+          }
+        : null,
+    },
+    days,
   };
 }


### PR DESCRIPTION
이번엔 로컬 환경에서 테스트를 habit.http에서 진행했습니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 새로운 습관 API 추가: 오늘의 습관 조회, 오늘의 습관 생성, 습관 완료/해제 토글, 주간 기록(요일별 집계) 조회.
  - 생성 시 중복 스킵 및 생성 요약(createdCount) 반환, 토글 시 당일 완료 상태 동기화 제공.
  - 인증 방식 통합(헤더/바디 허용).

- Bug Fixes
  - 입력 검증 강화 및 오류 상태 매핑(401/404/409 등) 일관화.
  - 캐시 비활성화 및 Vary 헤더로 최신 데이터 보장.

- Documentation
  - 로컬 시드 기반 HTTP 테스트 스크립트 추가(한국어 섹션 제목).
  - base, studyId, pwd, date 환경변수로 테스트 파라미터화.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->