### PR TITLE
fix: CORS 설정에 허용된 도메인 목록 'http://localhost:5173' 추가

### DIFF
--- a/src/common/cors.js
+++ b/src/common/cors.js
@@ -9,6 +9,7 @@ const corsOptions = {
   origin: [
     'https://eight-studyforest-team2-be.onrender.com',
     'http://localhost:3000',
+    'http://localhost:5173',
   ], // 허용할 도메인
   methods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE'], // 허용할 HTTP 메서드
   allowedHeaders: ['Content-Type', 'Authorization', 'x-study-password'], // 허용할 헤더


### PR DESCRIPTION
- hotfix : 프론트엔드에서 5173 포트 사용으로 해당 포트 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 해당 없음

- Chores
  - 로컬 개발/테스트 편의를 위해 CORS 허용 출처에 http://localhost:5173를 추가했습니다. 이제 이 포트에서 실행되는 프런트엔드가 API에 정상적으로 연결되어 기능 확인, 디버깅, 미리보기, 로컬 통합 테스트가 원활해집니다. 일반 사용자에게는 서비스 동작상의 변화가 없으며, 프로덕션 배포 환경의 보안 설정과 동작에는 영향이 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->