### PR TITLE
feat: 오늘의 습관 수정 및 단일 생성 API 작성 및 스웨거 추가

### DIFF
--- a/http/habit.http
+++ b/http/habit.http
@@ -2,15 +2,15 @@
 // 로컬 시드 데이터를 기준으로 테스트 http 요청
 @base = http://localhost:3000/api
 @studyId = 2
-@pwd = test
+@pwd = hMErO363AqI
 @date = 2025-09-02
 
 ### 1) 오늘의 습관 조회 (지금 해본 것)
 GET {{base}}/habits/today/{{studyId}}
 x-study-password: {{pwd}}
 
-### 2) 오늘의 습관 생성 (여기서 실제 생성됨)
-POST {{base}}/habits/today/{{studyId}}
+### 2) 오늘의 습관 일괄 생성 (여기서 실제 생성됨)
+POST {{base}}/habits/today/{{studyId}}/bulk
 Content-Type: application/json
 x-study-password: {{pwd}}
 
@@ -25,3 +25,22 @@ x-study-password: {{pwd}}
 ### 4) 주간 기록 조회 (해당 날짜가 속한 주)
 GET {{base}}/habits/week/{{studyId}}?date={{date}}
 x-study-password: {{pwd}}
+
+### 5) 오늘의 습관 단일 생성
+POST {{base}}/habits/today/{{studyId}}
+Content-Type: application/json
+x-study-password: {{pwd}}
+
+{
+  "title": "단어 50개"
+}
+
+### 6) 오늘의 습관 이름 변경 (오늘 포함 과거 전체 반영)
+@renameHabitId = 15
+PATCH {{base}}/habits/today/{{studyId}}/{{renameHabitId}}
+Content-Type: application/json
+x-study-password: {{pwd}}
+
+{
+  "title": "단어 100개"
+}

--- a/http/habit.http
+++ b/http/habit.http
@@ -2,7 +2,7 @@
 // 로컬 시드 데이터를 기준으로 테스트 http 요청
 @base = http://localhost:3000/api
 @studyId = 2
-@pwd = hMErO363AqI
+@pwd = test
 @date = 2025-09-02
 
 ### 1) 오늘의 습관 조회 (지금 해본 것)

--- a/src/api/controllers/habit.controllers.js
+++ b/src/api/controllers/habit.controllers.js
@@ -193,13 +193,7 @@ async function getWeekHabitsController(req, res, next) {
 async function renameTodayHabitController(req, res) {
   const studyId = parseStudyId(req);
   const password = parsePassword(req);
-  const habitIdStr = req.params.habitId;
-  if (!/^\d+$/.test(habitIdStr)) {
-    return res
-      .status(400)
-      .json({ message: 'habitId는 1 이상의 정수여야 합니다.' });
-  }
-  const habitId = Number.parseInt(habitIdStr, 10);
+  const habitId = parsePositiveParam(req, 'habitId');
 
   const newTitle = String(req.body?.title || '').trim();
   if (!newTitle) {
@@ -230,13 +224,7 @@ async function renameTodayHabitController(req, res) {
 async function deleteTodayHabitController(req, res) {
   const studyId = parseStudyId(req);
   const password = parsePassword(req);
-  const habitIdStr = req.params.habitId;
-  if (!/^\d+$/.test(habitIdStr)) {
-    return res
-      .status(400)
-      .json({ message: 'habitId는 1 이상의 정수여야 합니다.' });
-  }
-  const habitId = Number.parseInt(habitIdStr, 10);
+  const habitId = parsePositiveParam(req, 'habitId');
 
   try {
     const result = await deleteTodayHabitService({

--- a/src/api/controllers/habit.controllers.js
+++ b/src/api/controllers/habit.controllers.js
@@ -1,40 +1,48 @@
-// src/api/controllers/habit.controllers.js
 // 요청 파싱(params/query) + 입력 검증 + 서비스 호출 + 에러 변환
 
 import getTodayHabitsService, {
   createTodayHabitsService,
   toggleHabitService,
   getWeekHabitsService,
+  renameTodayHabitService,
+  deleteTodayHabitService,
+  addTodayHabitService,
 } from '../services/habit.services.js';
 
-/* 오늘의 습관 조회 */
+function parseStudyId(req) {
+  const studyIdStr = req.params.studyId;
+  if (!/^\d+$/.test(studyIdStr)) {
+    const e = new Error('studyId는 1 이상의 정수여야 합니다.');
+    e.status = 400;
+    throw e;
+  }
+  const studyId = Number.parseInt(studyIdStr, 10);
+  if (studyId <= 0) {
+    const e = new Error('studyId는 1 이상의 정수여야 합니다.');
+    e.status = 400;
+    throw e;
+  }
+  return studyId;
+}
+
+function parsePassword(req) {
+  const headerPwd = req.get('x-study-password');
+  const bodyPwd =
+    typeof req.body?.password === 'string' ? req.body.password : undefined;
+  const password =
+    typeof headerPwd === 'string' && headerPwd.length > 0 ? headerPwd : bodyPwd;
+  if (!password) {
+    const e = new Error('비밀번호가 필요합니다.');
+    e.status = 400;
+    throw e;
+  }
+  return password;
+}
+/*오늘의 습관 조회 */
 async function getTodayHabitsController(req, res, next) {
   try {
-    const studyIdStr = req.params.studyId;
-    if (!/^\d+$/.test(studyIdStr)) {
-      return res
-        .status(400)
-        .json({ message: 'studyId는 1 이상의 정수여야 합니다.' });
-    }
-    const studyId = Number.parseInt(studyIdStr, 10);
-    if (studyId <= 0) {
-      return res
-        .status(400)
-        .json({ message: 'studyId는 1 이상의 정수여야 합니다.' });
-    }
-
-    const headerPwd = req.get('x-study-password');
-    const bodyPwd =
-      typeof req.body?.password === 'string' ? req.body.password : undefined;
-    const password =
-      typeof headerPwd === 'string' && headerPwd.length > 0
-        ? headerPwd
-        : bodyPwd;
-
-    if (!password) {
-      return res.status(400).json({ message: '비밀번호가 필요합니다.' });
-    }
-
+    const studyId = parseStudyId(req);
+    const password = parsePassword(req);
     const data = await getTodayHabitsService({ studyId, password });
     res.set('Cache-Control', 'no-store');
     res.vary('x-study-password');
@@ -46,11 +54,13 @@ async function getTodayHabitsController(req, res, next) {
     if (err.name === 'NotFoundError') {
       return res.status(404).json({ message: err.message });
     }
-    return next(err);
+    return res
+      .status(err.status || 500)
+      .json({ message: err.message || 'SERVER_ERROR' });
   }
 }
 
-/* 오늘의 습관 생성 (배열로 들어온 title들을 오늘 날짜로 생성) */
+/* 습관 일괄 생성 (배열로 들어온 title들을 오늘 날짜로 생성)*/
 async function createTodayHabitsController(req, res, next) {
   try {
     const studyIdStr = req.params.studyId;
@@ -60,11 +70,6 @@ async function createTodayHabitsController(req, res, next) {
         .json({ message: 'studyId는 1 이상의 정수여야 합니다.' });
     }
     const studyId = Number.parseInt(studyIdStr, 10);
-    if (studyId <= 0) {
-      return res
-        .status(400)
-        .json({ message: 'studyId는 1 이상의 정수여야 합니다.' });
-    }
 
     const headerPwd = req.get('x-study-password');
     const bodyPwd =
@@ -74,11 +79,6 @@ async function createTodayHabitsController(req, res, next) {
         ? headerPwd
         : bodyPwd;
 
-    if (!password) {
-      return res.status(400).json({ message: '비밀번호가 필요합니다.' });
-    }
-
-    // 입력 정규화: habits(string[]) 또는 items[{title}]
     let titles = [];
     if (Array.isArray(req.body?.habits)) {
       titles = req.body.habits.filter(
@@ -108,7 +108,7 @@ async function createTodayHabitsController(req, res, next) {
       // Prisma unique 에러(동일 항목 일부 중복)
       return res
         .status(409)
-        .json({ message: '일부 습관은 이미 오늘 생성되어 있습니다.' });
+        .json({ message: '이 습관은 이미 생성되어 있습니다.' });
     }
     if (err.name === 'NotFoundError') {
       return res.status(404).json({ message: err.message });
@@ -117,7 +117,8 @@ async function createTodayHabitsController(req, res, next) {
   }
 }
 
-/* 오늘의 습관 체크/해제 (토글) */
+/** 오늘의 습관 체크/해제 (토글) */
+
 async function toggleHabitController(req, res, next) {
   try {
     const habitIdStr = req.params.habitId;
@@ -127,11 +128,6 @@ async function toggleHabitController(req, res, next) {
         .json({ message: 'habitId는 1 이상의 정수여야 합니다.' });
     }
     const habitId = Number.parseInt(habitIdStr, 10);
-    if (habitId <= 0) {
-      return res
-        .status(400)
-        .json({ message: 'habitId는 1 이상의 정수여야 합니다.' });
-    }
 
     const headerPwd = req.get('x-study-password');
     const bodyPwd =
@@ -140,10 +136,6 @@ async function toggleHabitController(req, res, next) {
       typeof headerPwd === 'string' && headerPwd.length > 0
         ? headerPwd
         : bodyPwd;
-
-    if (!password) {
-      return res.status(400).json({ message: '비밀번호가 필요합니다.' });
-    }
 
     const data = await toggleHabitService({ habitId, password });
     res.set('Cache-Control', 'no-store');
@@ -160,7 +152,8 @@ async function toggleHabitController(req, res, next) {
   }
 }
 
-/* 주간 습관 기록 조회 */
+/* 주간 습관 기록 조회*/
+
 async function getWeekHabitsController(req, res, next) {
   try {
     const studyIdStr = req.params.studyId;
@@ -170,11 +163,6 @@ async function getWeekHabitsController(req, res, next) {
         .json({ message: 'studyId는 1 이상의 정수여야 합니다.' });
     }
     const studyId = Number.parseInt(studyIdStr, 10);
-    if (studyId <= 0) {
-      return res
-        .status(400)
-        .json({ message: 'studyId는 1 이상의 정수여야 합니다.' });
-    }
 
     const headerPwd = req.get('x-study-password');
     const bodyPwd =
@@ -183,10 +171,6 @@ async function getWeekHabitsController(req, res, next) {
       typeof headerPwd === 'string' && headerPwd.length > 0
         ? headerPwd
         : bodyPwd;
-
-    if (!password) {
-      return res.status(400).json({ message: '비밀번호가 필요합니다.' });
-    }
 
     const dateStr =
       typeof req.query?.date === 'string' ? req.query.date : undefined;
@@ -205,12 +189,101 @@ async function getWeekHabitsController(req, res, next) {
     return next(err);
   }
 }
+/* 오늘의 습관 이름 변경*/
+async function renameTodayHabitController(req, res) {
+  const studyId = parseStudyId(req);
+  const password = parsePassword(req);
+  const habitIdStr = req.params.habitId;
+  if (!/^\d+$/.test(habitIdStr)) {
+    return res
+      .status(400)
+      .json({ message: 'habitId는 1 이상의 정수여야 합니다.' });
+  }
+  const habitId = Number.parseInt(habitIdStr, 10);
+
+  const newTitle = String(req.body?.title || '').trim();
+  if (!newTitle) {
+    return res.status(400).json({ message: 'title은 1자 이상이어야 합니다.' });
+  }
+
+  try {
+    const result = await renameTodayHabitService({
+      studyId,
+      password,
+      habitId,
+      newTitle,
+    });
+    return res.json(result);
+  } catch (err) {
+    if (err.name === 'UnauthorizedError')
+      return res.status(401).json({ message: err.message });
+    if (err.name === 'NotFoundError')
+      return res.status(404).json({ message: err.message });
+    if (err.name === 'ConflictError')
+      return res
+        .status(409)
+        .json({ message: err.message, conflicts: err.conflicts });
+    return res.status(500).json({ message: 'SERVER_ERROR' });
+  }
+}
+/*오늘의 습관 삭제*/
+async function deleteTodayHabitController(req, res) {
+  const studyId = parseStudyId(req);
+  const password = parsePassword(req);
+  const habitIdStr = req.params.habitId;
+  if (!/^\d+$/.test(habitIdStr)) {
+    return res
+      .status(400)
+      .json({ message: 'habitId는 1 이상의 정수여야 합니다.' });
+  }
+  const habitId = Number.parseInt(habitIdStr, 10);
+
+  try {
+    const result = await deleteTodayHabitService({
+      studyId,
+      password,
+      habitId,
+    });
+    return res.json(result);
+  } catch (err) {
+    if (err.name === 'UnauthorizedError')
+      return res.status(401).json({ message: err.message });
+    if (err.name === 'NotFoundError')
+      return res.status(404).json({ message: err.message });
+    return res.status(500).json({ message: 'SERVER_ERROR' });
+  }
+}
+/* 습관 단일 생성 */
+async function addTodayHabitController(req, res) {
+  const studyId = parseStudyId(req);
+  const password = parsePassword(req);
+  const title = String(req.body?.title || '').trim();
+  if (!title) {
+    return res.status(400).json({ message: 'title은 1자 이상이어야 합니다.' });
+  }
+
+  try {
+    const result = await addTodayHabitService({ studyId, password, title });
+    return res.status(201).json(result);
+  } catch (err) {
+    if (err.name === 'UnauthorizedError')
+      return res.status(401).json({ message: err.message });
+    if (err.name === 'NotFoundError')
+      return res.status(404).json({ message: err.message });
+    if (err.name === 'ConflictError')
+      return res.status(409).json({ message: err.message });
+    return res.status(500).json({ message: 'SERVER_ERROR' });
+  }
+}
 
 export {
   getTodayHabitsController,
   createTodayHabitsController,
   toggleHabitController,
   getWeekHabitsController,
+  renameTodayHabitController,
+  deleteTodayHabitController,
+  addTodayHabitController,
 };
 
 export default {
@@ -218,4 +291,7 @@ export default {
   createTodayHabitsController,
   toggleHabitController,
   getWeekHabitsController,
+  renameTodayHabitController,
+  deleteTodayHabitController,
+  addTodayHabitController,
 };

--- a/src/api/controllers/habit.controllers.js
+++ b/src/api/controllers/habit.controllers.js
@@ -8,7 +8,21 @@ import getTodayHabitsService, {
   deleteTodayHabitService,
   addTodayHabitService,
 } from '../services/habit.services.js';
-
+function parsePositiveParam(req, name) {
+  const raw = req.params?.[name];
+  if (!/^\d+$/.test(raw || '')) {
+    const e = new Error(`${name}는 1 이상의 정수여야 합니다.`);
+    e.status = 400;
+    throw e;
+  }
+  const n = Number.parseInt(raw, 10);
+  if (n <= 0) {
+    const e = new Error(`${name}는 1 이상의 정수여야 합니다.`);
+    e.status = 400;
+    throw e;
+  }
+  return n;
+}
 function parseStudyId(req) {
   const studyIdStr = req.params.studyId;
   if (!/^\d+$/.test(studyIdStr)) {

--- a/src/api/routes/habit.routes.js
+++ b/src/api/routes/habit.routes.js
@@ -1,5 +1,3 @@
-// Description: 습관(Habit) 관련 API 라우터 설정 파일입니다.
-
 /**
  * @swagger
  * tags:
@@ -124,7 +122,266 @@
  *               $ref: '#/components/schemas/ErrorResponse'
  */
 
-// 라이브러리 정의
+/**
+ * @swagger
+ * /api/habits/today/{studyId}/bulk:
+ *   post:
+ *     tags: [Habits]
+ *     summary: 오늘의 습관 일괄 생성
+ *     description: 문자열 배열을 오늘(KST 00:00) 날짜로 일괄 생성합니다. 이미 존재하는 항목은 스킵됩니다.
+ *     parameters:
+ *       - $ref: '#/components/parameters/StudyIdParam'
+ *     security:
+ *       - studyPassword: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               habits:
+ *                 type: array
+ *                 items: { type: string }
+ *                 example: ['물 1리터 마시기', '운동 30분', '회고 쓰기']
+ *     responses:
+ *       '201':
+ *         description: 생성 성공
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 study:
+ *                   type: object
+ *                   properties:
+ *                     id: { type: integer, example: 101 }
+ *                     name: { type: string, example: 'ROS2 보안 연구' }
+ *                     isActive: { type: boolean, example: true }
+ *                 now:  { type: string, example: '2025-09-02T11:23:45+09:00' }
+ *                 date: { type: string, example: '2025-09-02' }
+ *                 createdCount: { type: integer, example: 2 }
+ *                 habits:
+ *                   type: array
+ *                   items:
+ *                     $ref: '#/components/schemas/HabitTodayItem'
+ *       '400': { description: 잘못된 요청, content: { application/json: { schema: { $ref: '#/components/schemas/ErrorResponse' }}}}
+ *       '401': { description: 인증 실패,   content: { application/json: { schema: { $ref: '#/components/schemas/ErrorResponse' }}}}
+ *       '404': { description: 스터디 없음, content: { application/json: { schema: { $ref: '#/components/schemas/ErrorResponse' }}}}
+ *       '500': { description: 서버 오류,   content: { application/json: { schema: { $ref: '#/components/schemas/ErrorResponse' }}}}
+ */
+
+/**
+ * @swagger
+ * /api/habits/today/{studyId}:
+ *   post:
+ *     tags: [Habits]
+ *     summary: 오늘의 습관 단일 추가
+ *     description: 제목 하나를 오늘(KST 00:00) 날짜로 생성합니다. 같은 제목이 오늘 이미 있으면 409를 반환합니다.
+ *     parameters:
+ *       - $ref: '#/components/parameters/StudyIdParam'
+ *     security:
+ *       - studyPassword: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [title]
+ *             properties:
+ *               title:
+ *                 type: string
+ *                 example: '단어 50개'
+ *     responses:
+ *       '201':
+ *         description: 생성 성공
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 created:
+ *                   $ref: '#/components/schemas/HabitTodayItem'
+ *       '400': { description: 잘못된 요청, content: { application/json: { schema: { $ref: '#/components/schemas/ErrorResponse' }}}}
+ *       '401': { description: 인증 실패,   content: { application/json: { schema: { $ref: '#/components/schemas/ErrorResponse' }}}}
+ *       '404': { description: 스터디 없음, content: { application/json: { schema: { $ref: '#/components/schemas/ErrorResponse' }}}}
+ *       '409': { description: 중복 제목,   content: { application/json: { schema: { $ref: '#/components/schemas/ErrorResponse' }}}}
+ *       '500': { description: 서버 오류,   content: { application/json: { schema: { $ref: '#/components/schemas/ErrorResponse' }}}}
+ */
+
+/**
+ * @swagger
+ * /api/habits/{habitId}/toggle:
+ *   patch:
+ *     tags: [Habits]
+ *     summary: 오늘의 습관 체크/해제
+ *     description: 해당 habitId의 완료 여부를 토글합니다. (정책상 오늘 기록만 토글 허용)
+ *     parameters:
+ *       - name: habitId
+ *         in: path
+ *         required: true
+ *         schema: { type: integer }
+ *     security:
+ *       - studyPassword: []
+ *     responses:
+ *       '200':
+ *         description: 토글 성공
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 habitId:        { type: integer, example: 12 }
+ *                 isDone:         { type: boolean, example: true }
+ *                 date:
+ *                   type: string
+ *                   format: date-time
+ *                   example: '2025-09-02T00:00:00.000Z'
+ *                 habitHistoryId: { type: integer, example: 7 }
+ *       '400': { description: 잘못된 요청, content: { application/json: { schema: { $ref: '#/components/schemas/ErrorResponse' }}}}
+ *       '401': { description: 인증 실패,   content: { application/json: { schema: { $ref: '#/components/schemas/ErrorResponse' }}}}
+ *       '404': { description: 습관 없음,   content: { application/json: { schema: { $ref: '#/components/schemas/ErrorResponse' }}}}
+ *       '500': { description: 서버 오류,   content: { application/json: { schema: { $ref: '#/components/schemas/ErrorResponse' }}}}
+ */
+
+/**
+ * @swagger
+ * /api/habits/week/{studyId}:
+ *   get:
+ *     tags: [Habits]
+ *     summary: 주간 습관 기록 조회
+ *     description: KST 기준으로 월~일 주간 범위를 계산하여 습관 기록표를 반환합니다.
+ *     parameters:
+ *       - $ref: '#/components/parameters/StudyIdParam'
+ *       - name: date
+ *         in: query
+ *         required: false
+ *         schema: { type: string, example: '2025-09-02' }
+ *         description: 기준 날짜(YYYY-MM-DD). 미지정 시 오늘이 포함된 주.
+ *     security:
+ *       - studyPassword: []
+ *     responses:
+ *       '200':
+ *         description: 조회 성공
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 study:
+ *                   type: object
+ *                   properties:
+ *                     id:       { type: integer, example: 101 }
+ *                     name:     { type: string,  example: 'ROS2 보안 연구' }
+ *                     isActive: { type: boolean, example: true }
+ *                 week:
+ *                   type: object
+ *                   properties:
+ *                     start:    { type: string, example: '2025-09-01' }
+ *                     end:      { type: string, example: '2025-09-07' }
+ *                     weekDate:
+ *                       type: string
+ *                       format: date-time
+ *                       description: '@db.Date 저장 기준'
+ *                     summary:
+ *                       type: object
+ *                       nullable: true
+ *                       properties:
+ *                         monDone: { type: boolean }
+ *                         tueDone: { type: boolean }
+ *                         wedDone: { type: boolean }
+ *                         thuDone: { type: boolean }
+ *                         friDone: { type: boolean }
+ *                         satDone: { type: boolean }
+ *                         sunDone: { type: boolean }
+ *                 days:
+ *                   type: object
+ *                   additionalProperties:
+ *                     type: array
+ *                     items:
+ *                       type: object
+ *                       properties:
+ *                         habitId: { type: integer, example: 12 }
+ *                         title:   { type: string,  example: '운동 30분' }
+ *                         isDone:  { type: boolean, example: false }
+ *       '400': { description: 잘못된 요청, content: { application/json: { schema: { $ref: '#/components/schemas/ErrorResponse' }}}}
+ *       '401': { description: 인증 실패,   content: { application/json: { schema: { $ref: '#/components/schemas/ErrorResponse' }}}}
+ *       '404': { description: 스터디 없음, content: { application/json: { schema: { $ref: '#/components/schemas/ErrorResponse' }}}}
+ *       '500': { description: 서버 오류,   content: { application/json: { schema: { $ref: '#/components/schemas/ErrorResponse' }}}}
+ */
+
+/**
+ * @swagger
+ * /api/habits/today/{studyId}/{habitId}:
+ *   patch:
+ *     tags: [Habits]
+ *     summary: 오늘의 습관 이름 변경 (과거 전체 반영)
+ *     description: 기준 습관과 동일 제목의 과거~오늘 레코드를 모두 새 제목으로 변경합니다. 동일 기간에 새 제목이 이미 존재하면 409를 반환합니다.
+ *     parameters:
+ *       - $ref: '#/components/parameters/StudyIdParam'
+ *       - name: habitId
+ *         in: path
+ *         required: true
+ *         schema: { type: integer }
+ *     security:
+ *       - studyPassword: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [title]
+ *             properties:
+ *               title:
+ *                 type: string
+ *                 example: '단어 100개'
+ *     responses:
+ *       '200':
+ *         description: 변경 성공
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 updated: { type: integer, example: 4 }
+ *                 newTitle:{ type: string,  example: '단어 100개' }
+ *       '400': { description: 잘못된 요청,     content: { application/json: { schema: { $ref: '#/components/schemas/ErrorResponse' }}}}
+ *       '401': { description: 인증 실패,       content: { application/json: { schema: { $ref: '#/components/schemas/ErrorResponse' }}}}
+ *       '404': { description: 습관/스터디 없음, content: { application/json: { schema: { $ref: '#/components/schemas/ErrorResponse' }}}}
+ *       '409': { description: 새 제목 중복 충돌, content: { application/json: { schema: { $ref: '#/components/schemas/ErrorResponse' }}}}
+ *       '500': { description: 서버 오류,       content: { application/json: { schema: { $ref: '#/components/schemas/ErrorResponse' }}}}
+ *
+ *   delete:
+ *     tags: [Habits]
+ *     summary: 오늘부터 습관 종료 (과거 기록 보존)
+ *     description: 같은 제목의 오늘 이후(오늘 포함) 기록만 삭제합니다. 과거 기록은 유지됩니다.
+ *     parameters:
+ *       - $ref: '#/components/parameters/StudyIdParam'
+ *       - name: habitId
+ *         in: path
+ *         required: true
+ *         schema: { type: integer }
+ *     security:
+ *       - studyPassword: []
+ *     responses:
+ *       '200':
+ *         description: 삭제 성공
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 deleted: { type: integer, example: 2 }
+ *       '400': { description: 잘못된 요청,     content: { application/json: { schema: { $ref: '#/components/schemas/ErrorResponse' }}}}
+ *       '401': { description: 인증 실패,       content: { application/json: { schema: { $ref: '#/components/schemas/ErrorResponse' }}}}
+ *       '404': { description: 습관/스터디 없음, content: { application/json: { schema: { $ref: '#/components/schemas/ErrorResponse' }}}}
+ *       '500': { description: 서버 오류,       content: { application/json: { schema: { $ref: '#/components/schemas/ErrorResponse' }}}}
+ */
+
+// Description: 습관(Habit) 관련 API 라우터 설정 파일입니다.
+
 import express from 'express';
 import corsMiddleware from '../../common/cors.js';
 
@@ -135,6 +392,9 @@ import {
   createTodayHabitsController,
   toggleHabitController,
   getWeekHabitsController,
+  renameTodayHabitController,
+  deleteTodayHabitController,
+  addTodayHabitController,
 } from '../controllers/habit.controllers.js';
 
 const router = express.Router();
@@ -147,9 +407,9 @@ router.get(
   errorMiddleware.asyncHandler(getTodayHabitsController),
 );
 
-// 오늘의 습관 생성
+// 습관 일괄 생성
 router.post(
-  '/habits/today/:studyId',
+  '/habits/today/:studyId/bulk',
   errorMiddleware.asyncHandler(createTodayHabitsController),
 );
 
@@ -164,7 +424,23 @@ router.get(
   '/habits/week/:studyId',
   errorMiddleware.asyncHandler(getWeekHabitsController),
 );
+// 오늘의 습관 이름 변경(오늘 포함 과거 전체에 반영)
+router.patch(
+  '/habits/today/:studyId/:habitId',
+  errorMiddleware.asyncHandler(renameTodayHabitController),
+);
 
+// 오늘부터 습관 종료(삭제) — 과거 기록 보존
+router.delete(
+  '/habits/today/:studyId/:habitId',
+  errorMiddleware.asyncHandler(deleteTodayHabitController),
+);
+
+// 오늘부터 새로운 습관 추가 — 과거엔 표시 X
+router.post(
+  '/habits/today/:studyId',
+  errorMiddleware.asyncHandler(addTodayHabitController),
+);
 // 에러 핸들링 미들웨어 (맨 마지막)
 router.use(errorMiddleware.errorHandler);
 

--- a/src/api/routes/habit.routes.js
+++ b/src/api/routes/habit.routes.js
@@ -346,7 +346,7 @@
  *               type: object
  *               properties:
  *                 updated: { type: integer, example: 4 }
- *                 newTitle:{ type: string,  example: '단어 100개' }
+ *                 newTitle: { type: string,  example: '단어 100개' }
  *       '400': { description: 잘못된 요청,     content: { application/json: { schema: { $ref: '#/components/schemas/ErrorResponse' }}}}
  *       '401': { description: 인증 실패,       content: { application/json: { schema: { $ref: '#/components/schemas/ErrorResponse' }}}}
  *       '404': { description: 습관/스터디 없음, content: { application/json: { schema: { $ref: '#/components/schemas/ErrorResponse' }}}}

--- a/src/api/services/habit.services.js
+++ b/src/api/services/habit.services.js
@@ -368,5 +368,163 @@ export async function getWeekHabitsService({ studyId, password, dateStr }) {
     days,
   };
 }
+// 오늘의 습관 이름 수정
+export async function renameTodayHabitService({
+  studyId,
+  password,
+  habitId,
+  newTitle,
+}) {
+  await assertStudyWithPassword({ studyId, password });
+  const { endUtc } = getKSTDayRange(); // 오늘 24:00(KST) 기준
 
+  // 1) 오늘 습관(=기준 습관) 찾기 + 소속 검증
+  const base = await prisma.habit.findFirst({
+    where: {
+      id: habitId,
+      date: { lt: endUtc }, // 오늘(포함) 레코드여야 함
+      habitHistory: { is: { studyId } },
+    },
+    select: { id: true, habit: true, habitHistoryId: true, date: true },
+  });
+  if (!base) {
+    const e = new Error('해당 습관을 찾을 수 없습니다(오늘 기록이 아님).');
+    e.name = 'NotFoundError';
+    throw e;
+  }
+
+  // 2) 충돌 검사
+  const conflicts = await prisma.habit.findMany({
+    where: {
+      habitHistoryId: base.habitHistoryId,
+      habit: newTitle,
+      date: { lt: endUtc },
+    },
+    select: { id: true, date: true },
+  });
+  if (conflicts.length > 0) {
+    const e = new Error('동일 날짜에 같은 이름의 습관이 이미 존재합니다.');
+    e.name = 'ConflictError';
+    e.conflicts = conflicts.map(c => c.date);
+    throw e;
+  }
+
+  // 3) 변경 대상 조회
+  const targets = await prisma.habit.findMany({
+    where: {
+      habitHistoryId: base.habitHistoryId,
+      habit: base.habit,
+      date: { lt: endUtc },
+    },
+    select: { id: true },
+  });
+  if (targets.length === 0) {
+    return { updated: 0, newTitle };
+  }
+
+  // 4) 일괄 변경
+  const updated = await prisma.habit.updateMany({
+    where: { id: { in: targets.map(t => t.id) } },
+    data: { habit: newTitle },
+  });
+
+  return { updated: updated.count, newTitle };
+}
+
+// 오늘의 습관 삭제
+
+export async function deleteTodayHabitService({ studyId, password, habitId }) {
+  await assertStudyWithPassword({ studyId, password });
+  const { startUtc } = getKSTDayRange();
+
+  const base = await prisma.habit.findFirst({
+    where: {
+      id: habitId,
+      habitHistory: { is: { studyId } },
+    },
+    select: { id: true, habit: true, habitHistoryId: true },
+  });
+  if (!base) {
+    const e = new Error('해당 습관을 찾을 수 없습니다.');
+    e.name = 'NotFoundError';
+    throw e;
+  }
+
+  const del = await prisma.habit.deleteMany({
+    where: {
+      habitHistoryId: base.habitHistoryId,
+      habit: base.habit,
+      date: { gte: startUtc }, // 오늘부터(미래 포함) 제거
+    },
+  });
+
+  return { deleted: del.count };
+}
+
+//새로운 습관 추가
+
+export async function addTodayHabitService({ studyId, password, title }) {
+  // 스터디 인증 + 오늘 HabitHistory 보장
+  const study = await assertStudyWithPassword({ studyId, password });
+  const { startUtc, endUtc } = getKSTDayRange();
+
+  // 1) 오늘 해당 스터디의 HabitHistory 가져오기
+  let hh = await prisma.habitHistory.findFirst({
+    where: { studyId: study.id, weekDate: { lte: endUtc } }, // 단순화: 기존 주간 히스토리 재사용
+    orderBy: { weekDate: 'desc' },
+  });
+
+  if (!hh) {
+    // 최초 생성 케이스
+    hh = await prisma.habitHistory.create({
+      data: {
+        studyId: study.id,
+        weekDate: new Date(startUtc), // 오늘 00:00(KST)의 날짜부만 쓰는 셈
+      },
+    });
+  }
+
+  // 2) 오늘 중복 검사 (unique: [habitHistoryId, date, habit])
+  const dup = await prisma.habit.findFirst({
+    where: {
+      habitHistoryId: hh.id,
+      date: { gte: startUtc, lt: endUtc },
+      habit: title.trim(),
+    },
+    select: { id: true },
+  });
+  if (dup) {
+    const e = new Error('오늘 이미 같은 이름의 습관이 존재합니다.');
+    e.name = 'ConflictError';
+    throw e;
+  }
+
+  // 3) 오늘 레코드 생성
+  const created = await prisma.habit.create({
+    data: {
+      habitHistoryId: hh.id,
+      habit: title.trim(),
+      date: new Date(startUtc),
+      isDone: false,
+    },
+    select: {
+      id: true,
+      habit: true,
+      date: true,
+      isDone: true,
+      habitHistoryId: true,
+      createdAt: true,
+    },
+  });
+
+  return {
+    created: {
+      habitId: created.id,
+      title: created.habit,
+      date: created.date,
+      isDone: created.isDone,
+      habitHistoryId: created.habitHistoryId,
+    },
+  };
+}
 export { getKSTDayRange, getKSTWeekRange, assertStudyWithPassword };

--- a/src/api/services/habit.services.js
+++ b/src/api/services/habit.services.js
@@ -378,57 +378,59 @@ export async function renameTodayHabitService({
   await assertStudyWithPassword({ studyId, password });
   const { endUtc } = getKSTDayRange(); // 오늘 24:00(KST) 기준
 
-  // 1) 오늘 습관(=기준 습관) 찾기 + 소속 검증
-  const base = await prisma.habit.findFirst({
-    where: {
-      id: habitId,
-      date: { lt: endUtc }, // 오늘(포함) 레코드여야 함
-      habitHistory: { is: { studyId } },
-    },
-    select: { id: true, habit: true, habitHistoryId: true, date: true },
-  });
-  if (!base) {
-    const e = new Error('해당 습관을 찾을 수 없습니다(오늘 기록이 아님).');
-    e.name = 'NotFoundError';
-    throw e;
-  }
+  return await prisma.$transaction(async tx => {
+    // 1) 오늘 습관(=기준 습관) 찾기 + 소속 검증
+    const base = await tx.habit.findFirst({
+      where: {
+        id: habitId,
+        date: { lt: endUtc }, // 오늘(포함) 레코드여야 함
+        habitHistory: { is: { studyId } },
+      },
+      select: { id: true, habit: true, habitHistoryId: true, date: true },
+    });
+    if (!base) {
+      const e = new Error('해당 습관을 찾을 수 없습니다(오늘 기록이 아님).');
+      e.name = 'NotFoundError';
+      throw e;
+    }
 
-  // 2) 충돌 검사
-  const conflicts = await prisma.habit.findMany({
-    where: {
-      habitHistoryId: base.habitHistoryId,
-      habit: newTitle,
-      date: { lt: endUtc },
-    },
-    select: { id: true, date: true },
-  });
-  if (conflicts.length > 0) {
-    const e = new Error('동일 날짜에 같은 이름의 습관이 이미 존재합니다.');
-    e.name = 'ConflictError';
-    e.conflicts = conflicts.map(c => c.date);
-    throw e;
-  }
+    // 2) 충돌 검사
+    const conflicts = await tx.habit.findMany({
+      where: {
+        habitHistoryId: base.habitHistoryId,
+        habit: newTitle,
+        date: { lt: endUtc },
+      },
+      select: { id: true, date: true },
+    });
+    if (conflicts.length > 0) {
+      const e = new Error('동일 날짜에 같은 이름의 습관이 이미 존재합니다.');
+      e.name = 'ConflictError';
+      e.conflicts = conflicts.map(c => c.date);
+      throw e;
+    }
 
-  // 3) 변경 대상 조회
-  const targets = await prisma.habit.findMany({
-    where: {
-      habitHistoryId: base.habitHistoryId,
-      habit: base.habit,
-      date: { lt: endUtc },
-    },
-    select: { id: true },
-  });
-  if (targets.length === 0) {
-    return { updated: 0, newTitle };
-  }
+    // 3) 변경 대상 조회
+    const targets = await tx.habit.findMany({
+      where: {
+        habitHistoryId: base.habitHistoryId,
+        habit: base.habit,
+        date: { lt: endUtc },
+      },
+      select: { id: true },
+    });
+    if (targets.length === 0) {
+      return { updated: 0, newTitle };
+    }
 
-  // 4) 일괄 변경
-  const updated = await prisma.habit.updateMany({
-    where: { id: { in: targets.map(t => t.id) } },
-    data: { habit: newTitle },
-  });
+    // 4) 일괄 변경
+    const updated = await tx.habit.updateMany({
+      where: { id: { in: targets.map(t => t.id) } },
+      data: { habit: newTitle },
+    });
 
-  return { updated: updated.count, newTitle };
+    return { updated: updated.count, newTitle };
+  });
 }
 
 // 오늘의 습관 삭제
@@ -467,64 +469,70 @@ export async function addTodayHabitService({ studyId, password, title }) {
   // 스터디 인증 + 오늘 HabitHistory 보장
   const study = await assertStudyWithPassword({ studyId, password });
   const { startUtc, endUtc } = getKSTDayRange();
-
-  // 1) 오늘 해당 스터디의 HabitHistory 가져오기
-  let hh = await prisma.habitHistory.findFirst({
-    where: { studyId: study.id, weekDate: { lte: endUtc } }, // 단순화: 기존 주간 히스토리 재사용
-    orderBy: { weekDate: 'desc' },
-  });
-
-  if (!hh) {
-    // 최초 생성 케이스
-    hh = await prisma.habitHistory.create({
-      data: {
-        studyId: study.id,
-        weekDate: new Date(startUtc), // 오늘 00:00(KST)의 날짜부만 쓰는 셈
+  const { weekDateOnly } = getKSTWeekRange(startUtc);
+  return await prisma.$transaction(async tx => {
+    // 1) 오늘 해당 스터디의 HabitHistory 가져오기
+    let hh = await tx.habitHistory.findUnique({
+      where: {
+        studyId_weekDate: {
+          studyId: study.id,
+          weekDate: weekDateOnly,
+        },
       },
     });
-  }
 
-  // 2) 오늘 중복 검사 (unique: [habitHistoryId, date, habit])
-  const dup = await prisma.habit.findFirst({
-    where: {
-      habitHistoryId: hh.id,
-      date: { gte: startUtc, lt: endUtc },
-      habit: title.trim(),
-    },
-    select: { id: true },
+    if (!hh) {
+      // 최초 생성 케이스
+      hh = await tx.habitHistory.create({
+        data: {
+          studyId: study.id,
+          weekDate: weekDateOnly, // 오늘 00:00(KST)의 날짜부만 쓰는 셈
+        },
+      });
+    }
+
+    // 2) 오늘 중복 검사 (unique: [habitHistoryId, date, habit])
+    const dup = await prisma.habit.findFirst({
+      where: {
+        habitHistoryId: hh.id,
+        date: { gte: startUtc, lt: endUtc },
+        habit: title.trim(),
+      },
+      select: { id: true },
+    });
+    if (dup) {
+      const e = new Error('오늘 이미 같은 이름의 습관이 존재합니다.');
+      e.name = 'ConflictError';
+      throw e;
+    }
+
+    // 3) 오늘 레코드 생성
+    const created = await tx.habit.create({
+      data: {
+        habitHistoryId: hh.id,
+        habit: title.trim(),
+        date: new Date(startUtc),
+        isDone: false,
+      },
+      select: {
+        id: true,
+        habit: true,
+        date: true,
+        isDone: true,
+        habitHistoryId: true,
+        createdAt: true,
+      },
+    });
+
+    return {
+      created: {
+        habitId: created.id,
+        title: created.habit,
+        date: created.date,
+        isDone: created.isDone,
+        habitHistoryId: created.habitHistoryId,
+      },
+    };
   });
-  if (dup) {
-    const e = new Error('오늘 이미 같은 이름의 습관이 존재합니다.');
-    e.name = 'ConflictError';
-    throw e;
-  }
-
-  // 3) 오늘 레코드 생성
-  const created = await prisma.habit.create({
-    data: {
-      habitHistoryId: hh.id,
-      habit: title.trim(),
-      date: new Date(startUtc),
-      isDone: false,
-    },
-    select: {
-      id: true,
-      habit: true,
-      date: true,
-      isDone: true,
-      habitHistoryId: true,
-      createdAt: true,
-    },
-  });
-
-  return {
-    created: {
-      habitId: created.id,
-      title: created.habit,
-      date: created.date,
-      isDone: created.isDone,
-      habitHistoryId: created.habitHistoryId,
-    },
-  };
 }
 export { getKSTDayRange, getKSTWeekRange, assertStudyWithPassword };


### PR DESCRIPTION
오늘의 습관 수정 API 및 단일 생성 API 작성하고 스웨거 추가했습니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 오늘의 습관 단일 생성(POST /habits/today/:studyId), 이름 변경(PATCH /habits/today/:studyId/:habitId), 삭제(DELETE /habits/today/:studyId/:habitId) 및 대량 생성(POST /habits/today/:studyId/bulk) 추가
- 변경사항
  - 대량 생성 경로 변경 및 요청에 JSON 바디와 x-study-password 헤더 필요
  - 이름 변경은 오늘 포함 과거 항목들까지 반영, 삭제는 오늘 이후 항목들까지 제거
  - 중복 생성 시 409 응답과 사용자 친화적 메시지 제공; 에러 응답 및 입력 검증 일관화
- 문서
  - 관련 API 문서(Swagger/OpenAPI) 추가 및 갱신
<!-- end of auto-generated comment: release notes by coderabbit.ai -->