### PR TITLE
fix: 목록 조회 API 변경

### DIFF
--- a/http/study.http
+++ b/http/study.http
@@ -10,7 +10,7 @@ GET https://eight-studyforest-team2-be.onrender.com/api/studies?offset=0&pointOr
 
 ###
 
-GET http://localhost:3000/api/studies?offset=0&pointOrder=desc&recentOrder=recent
+GET http://localhost:3000/api/studies?offset=0&pointOrder=desc&recentOrder=recent&isActive=false
 
 ###
 

--- a/src/api/controllers/study.controllers.js
+++ b/src/api/controllers/study.controllers.js
@@ -33,7 +33,15 @@ async function controlStudyList(req, res) {
       : 'recent';
   const pointOrder = pointOrderRaw === 'desc' ? 'desc' : 'asc';
   const recentOrder = recentOrderRaw === 'old' ? 'old' : 'recent';
-  const isActive = req.query.isActive;
+  const isActiveRaw = req.query.isActive;
+  const isActive =
+    typeof isActiveRaw === 'string'
+      ? (/^(true|1)$/i.test(isActiveRaw)
+          ? true
+          : (/^(false|0)$/i.test(isActiveRaw)
+              ? false
+              : undefined))
+      : undefined;
 
   /* 서비스 호출 */
   const studyList = await studyService.serviceStudyList({

--- a/src/api/controllers/study.controllers.js
+++ b/src/api/controllers/study.controllers.js
@@ -33,6 +33,7 @@ async function controlStudyList(req, res) {
       : 'recent';
   const pointOrder = pointOrderRaw === 'desc' ? 'desc' : 'asc';
   const recentOrder = recentOrderRaw === 'old' ? 'old' : 'recent';
+  const isActive = req.query.isActive;
 
   /* 서비스 호출 */
   const studyList = await studyService.serviceStudyList({
@@ -41,6 +42,7 @@ async function controlStudyList(req, res) {
     keyword,
     pointOrder,
     recentOrder,
+    isActive,
   });
 
   /* 결과 반환 */

--- a/src/api/routes/study.routes.js
+++ b/src/api/routes/study.routes.js
@@ -188,7 +188,7 @@
  *           oneOf:
  *             - type: string
  *               minLength: 1
- *               description: 이모지 심볼(예: "👍")
+ *               description: 이모지 심볼(예 "👍")
  *               example: 👍
  *             - type: integer
  *               minimum: 1

--- a/src/api/routes/study.routes.js
+++ b/src/api/routes/study.routes.js
@@ -285,6 +285,17 @@
  *         name: recentOrder
  *         schema: { type: string, enum: [recent, old] }
  *         example: recent
+ *       - in: query
+ *         name: active
+ *         schema: { type: boolean }
+ *         example: true
+ *     description: |
+ *       - offset: (선택) 건너뛸 레코드 수(기본값 0)
+ *       - limit: (선택) 최대 조회 건수(기본값 6, 최대 50)
+ *       - keyword: (선택) 스터디 이름/닉네임/내용 검색 키워드(부분 일치)
+ *       - pointOrder: (선택) 포인트 합계 기준 정렬(asc/desc, 기본값 desc)
+ *       - recentOrder: (선택) 생성일 기준 정렬(recent/old, 기본값 recent)
+ *       - active: (선택) 활성화 상태 필터(true/false, 미지정 시 전체)
  *     responses:
  *       200:
  *         description: 페이징 목록

--- a/src/api/services/study.services.js
+++ b/src/api/services/study.services.js
@@ -36,9 +36,9 @@ async function serviceGetStudy(){
 
 // 스터디 목록 조회 API 서비스
 async function serviceStudyList(options) {
-  const { offset, limit, keyword, pointOrder, recentOrder } = options;
+  const { offset, limit, keyword, pointOrder, recentOrder, isActive } = options;
   const where = {
-    isActive: true,
+    isActive: JSON.parse(isActive),
     ...(keyword
       ? {
           name: {


### PR DESCRIPTION
- isActive 쿼리를 추가하여, 비공개 게시글만 따로 조회할 수 있도록 설정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신기능**
  - 스터디 목록 조회에서 isActive/active 쿼리로 활성/비활성 스터디를 필터링할 수 있습니다.
  - 예시 요청이 isActive=false를 포함하도록 갱신되었습니다.

- **문서**
  - API 문서의 이모지 예시 표기를 정리했고, 목록 조회의 active 파라미터 설명과 예시를 추가/갱신했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->