### PR TITLE
hotfix: 정렬 관련 수정사항 반영

### DIFF
--- a/http/study.http
+++ b/http/study.http
@@ -7,10 +7,9 @@
 @pwd = test
 # 조회 API를 위한 파라미터 설정
 @offset = 0
-@pointOrder = desc
-@recentOrder = recent
-@isActive = false
-@keyword = 시험
+@order = points_asc
+@isActive = true
+@keyword =
 
 ### 1) [로컬] 스터디 관리 페이지 조회 (관리자용)
 
@@ -18,11 +17,11 @@ GET {{base_local}}/studies/manage
 
 ### 2) [배포] 스터디 조회 API (offset, pointOrder, recentOrder, isActive, keyword)
 
-GET {{base_prod}}/studies?offset={{offset}}&pointOrder={{pointOrder}}&recentOrder={{recentOrder}}&isActive={{isActive}}&keyword={{keyword}}
+GET {{base_prod}}/studies?offset={{offset}}&sort={{order}}&isActive={{isActive}}&keyword={{keyword}}
 
 ### 2) [로컬] 스터디 조회 API (offset, pointOrder, recentOrder, isActive, keyword)
 
-GET {{base_local}}/studies?offset={{offset}}&pointOrder={{pointOrder}}&recentOrder={{recentOrder}}&isActive={{isActive}}&keyword={{keyword}}
+GET {{base_local}}/studies?offset={{offset}}&sort={{order}}&isActive={{isActive}}&keyword={{keyword}}
 
 ### 3) [배포] 스터디 생성 API
 

--- a/src/api/controllers/study.controllers.js
+++ b/src/api/controllers/study.controllers.js
@@ -1,8 +1,10 @@
 // 요청 파싱(params/query/body) + 입력 검증 결과 처리
 import { assert } from 'superstruct';
-import { createStudy, patchStudy } from '../structs.js';
-import studyService from '../services/study.services.js';
 import argon2 from 'argon2';
+// eslint-disable-next-line import/extensions
+import { createStudy, patchStudy } from '../structs.js';
+// eslint-disable-next-line import/extensions
+import studyService from '../services/study.services.js';
 
 // 관리를 위한 전체 스터디 목록 조회 API 컨트롤러
 async function controlGetStudy(req, res) {
@@ -16,45 +18,81 @@ async function controlGetStudy(req, res) {
 // 스터디 목록 조회 API 컨트롤러
 async function controlStudyList(req, res) {
   /* 쿼리 파라미터 파싱 및 입력 검증 */
-  const offsetRaw = Number.parseInt(req.query.offset ?? '0', 10);
-  const limitRaw = Number.parseInt(req.query.limit ?? '6', 10);
-  const offset = Number.isFinite(offsetRaw) && offsetRaw >= 0 ? offsetRaw : 0;
+  // 1) 숫자 파라미터 정규화
+  const hasOffset =
+    req.query && Object.prototype.hasOwnProperty.call(req.query, 'offset');
+  const hasLimit =
+    req.query && Object.prototype.hasOwnProperty.call(req.query, 'limit');
+
+  const offsetStr = hasOffset ? String(req.query.offset) : '0';
+  const limitStr = hasLimit ? String(req.query.limit) : '6';
+
+  const offsetNum = Number.parseInt(offsetStr, 10);
+  const limitNum = Number.parseInt(limitStr, 10);
+
+  const offset = Number.isInteger(offsetNum) && offsetNum >= 0 ? offsetNum : 0;
   const limit =
-    Number.isFinite(limitRaw) && limitRaw > 0 ? Math.min(limitRaw, 50) : 6; // 상한 50
+    Number.isInteger(limitNum) && limitNum > 0 && limitNum <= 50 ? limitNum : 6;
+
+  // 2) 정렬 단일화: sort (recent | old | points_desc | points_asc)
+  //    - 한국어 라벨 및 레거시 파라미터(recentOrder/pointOrder)도 매핑 지원
+  let sort = '';
+  if (req.query && typeof req.query.sort === 'string') {
+    const s = req.query.sort.toLowerCase();
+    if (s === 'recent') sort = 'recent';
+    else if (s === 'old') sort = 'old';
+    else if (s === 'points_desc') sort = 'points_desc';
+    else if (s === 'points_asc') sort = 'points_asc';
+    // eslint-disable-next-line no-dupe-else-if
+  } else if (req.query && typeof req.query.sort === 'string') {
+    // no-op (위에서 처리)
+  } else if (req.query && typeof req.query.recentOrder === 'string') {
+    const r = req.query.recentOrder.toLowerCase();
+    if (r === 'recent' || req.query.recentOrder === '최근 순') sort = 'recent';
+    else if (r === 'old' || req.query.recentOrder === '오래된 순') sort = 'old';
+  } else if (req.query && typeof req.query.pointOrder === 'string') {
+    const p = req.query.pointOrder.toLowerCase();
+    if (p === 'desc' || req.query.pointOrder === '많은 포인트 순')
+      sort = 'points_desc';
+    else if (p === 'asc' || req.query.pointOrder === '적은 포인트 순')
+      sort = 'points_asc';
+  }
+  // 한국어 라벨 직접 전달 시 처리
+  if (!sort && req.query && typeof req.query.sort === 'string') {
+    const k = req.query.sort;
+    if (k === '최근 순') sort = 'recent';
+    else if (k === '오래된 순') sort = 'old';
+    else if (k === '많은 포인트 순') sort = 'points_desc';
+    else if (k === '적은 포인트 순') sort = 'points_asc';
+  }
+  if (!sort) sort = 'recent'; // 기본값
+
+  // 3) 검색어/공개여부 파싱
   const keyword =
-    typeof req.query.keyword === 'string' ? req.query.keyword.trim() : '';
-  const pointOrderRaw =
-    typeof req.query.pointOrder === 'string'
-      ? req.query.pointOrder.toLowerCase()
-      : 'asc';
-  const recentOrderRaw =
-    typeof req.query.recentOrder === 'string'
-      ? req.query.recentOrder.toLowerCase()
-      : 'recent';
-  const pointOrder = pointOrderRaw === 'desc' ? 'desc' : 'asc';
-  const recentOrder = recentOrderRaw === 'old' ? 'old' : 'recent';
-  const isActiveRaw = req.query.isActive;
-  const isActive =
-    typeof isActiveRaw === 'string'
-      ? (/^(true|1)$/i.test(isActiveRaw)
-          ? true
-          : (/^(false|0)$/i.test(isActiveRaw)
-              ? false
-              : undefined))
-      : undefined;
+    req.query && typeof req.query.keyword === 'string'
+      ? req.query.keyword.trim()
+      : '';
+
+  let isActive; // undefined | boolean
+  if (req.query && typeof req.query.isActive === 'string') {
+    const v = req.query.isActive.toLowerCase();
+    if (v === 'true' || v === '1') isActive = true;
+    else if (v === 'false' || v === '0') isActive = false;
+  }
 
   /* 서비스 호출 */
-  const studyList = await studyService.serviceStudyList({
+  // 4) 서비스 호출
+  const { studies, totalCount } = await studyService.serviceStudyList({
     offset,
     limit,
-    keyword,
-    pointOrder,
-    recentOrder,
+    sort,
     isActive,
+    keyword,
   });
 
   /* 결과 반환 */
-  res.json(studyList);
+  // 5) 응답
+  return res.status(200).json({ studies, totalCount });
 }
 
 // 스터디 생성 API 컨트롤러
@@ -89,11 +127,10 @@ async function controlStudyCreate(req, res) {
 async function controlStudyUpdate(req, res) {
   /* 쿼리 파라미터 파싱 및 입력 검증 */
   assert(req.body, patchStudy);
-  const { nick, name, content, img, password, isActive } =
-    req.body;
+  const { nick, name, content, img, password, isActive } = req.body;
   const studyId = Number.parseInt(req.params.studyId, 10);
   if (!Number.isFinite(studyId) || studyId <= 0) {
-    const err = new Error("유효하지 않은 스터디 ID입니다.");
+    const err = new Error('유효하지 않은 스터디 ID입니다.');
     err.status = 400;
     err.code = 'INVALID_STUDY_ID';
     throw err;
@@ -125,7 +162,6 @@ async function controlStudyUpdate(req, res) {
 
   /* 결과 반환 */
   res.status(200).json(studyUpdate);
-
 }
 
 // 스터디 삭제 API 컨트롤러
@@ -139,7 +175,7 @@ async function controlStudyDelete(req, res) {
     throw err;
   }
 
-  const password = req.body.password;
+  const { password } = req.body;
   if (typeof password !== 'string' || password.length === 0) {
     const err = new Error('비밀번호가 누락되었습니다.');
     err.status = 400;
@@ -189,7 +225,7 @@ async function controlEmojiIncrement(req, res) {
     throw err;
   }
 
-  const { id, _, count  } = req.body;
+  const { id, _, count } = req.body;
   const emojiSymbol = id.toString();
   if (typeof emojiSymbol !== 'string' || emojiSymbol.length === 0) {
     const err = new Error('이모지 심볼이 누락되었습니다.');
@@ -227,7 +263,7 @@ async function controlEmojiDecrement(req, res) {
     throw err;
   }
 
-  const { id, _, count  } = req.body;
+  const { id, _, count } = req.body;
   const emojiSymbol = id.toString();
   if (typeof emojiSymbol !== 'string' || emojiSymbol.length === 0) {
     const err = new Error('이모지 심볼이 누락되었습니다.');

--- a/src/api/services/study.services.js
+++ b/src/api/services/study.services.js
@@ -6,7 +6,7 @@ import argon2 from 'argon2';
 const prisma = new PrismaClient();
 
 // 관리를 위한 전체 스터디 목록 조회 API 서비스
-async function serviceGetStudy(){
+async function serviceGetStudy() {
   try {
     return await prisma.study.findMany({
       orderBy: { createdAt: 'desc' },
@@ -38,22 +38,29 @@ async function serviceGetStudy(){
 async function serviceStudyList(options) {
   // 0) 파라미터 정규화
   const rawOffset = options.offset;
-  const rawLimit       = options.limit;
-  const rawPointOrder  = options.pointOrder;   // 'asc' | 'desc' | undefined
-  const rawRecentOrder = options.recentOrder;  // 'recent' | 'old' | undefined
-  const rawIsActive    = options.isActive;     // boolean | undefined
-  const rawKeyword     = options.keyword;      // string | undefined
+  const rawLimit = options.limit;
+  const rawSort = options.sort;
+  const rawIsActive = options.isActive;
+  const rawKeyword = options.keyword;
 
-  const offset = (typeof rawOffset === 'number' && Number.isInteger(rawOffset) && rawOffset >= 0) ? rawOffset : 0;
-  const limit  = (typeof rawLimit  === 'number' && Number.isInteger(rawLimit)  && rawLimit  > 0 && rawLimit  <= 50) ? rawLimit  : 6;
+  const offset =
+    typeof rawOffset === 'number' &&
+    Number.isInteger(rawOffset) &&
+    rawOffset >= 0
+      ? rawOffset
+      : 0;
+  const limit =
+    typeof rawLimit === 'number' &&
+    Number.isInteger(rawLimit) &&
+    rawLimit > 0 &&
+    rawLimit <= 50
+      ? rawLimit
+      : 6;
+  const sort = typeof rawSort === 'string' ? rawSort : 'recent';
 
-  const pointOrder = (rawPointOrder === 'asc' || rawPointOrder === 'desc') ? rawPointOrder : undefined;
-  const recentOrder = (rawRecentOrder === 'old') ? 'old' : 'recent';
-
-  const hasIsActive = (typeof rawIsActive === 'boolean');
+  const hasIsActive = typeof rawIsActive === 'boolean';
   const isActiveVal = hasIsActive ? rawIsActive : undefined;
-
-  const keyword = (typeof rawKeyword === 'string') ? rawKeyword : '';
+  const keyword = typeof rawKeyword === 'string' ? rawKeyword : '';
 
   try {
     // 1) where 구성
@@ -61,149 +68,185 @@ async function serviceStudyList(options) {
     if (hasIsActive) studyWhere.isActive = isActiveVal;
     if (keyword.trim() !== '') {
       studyWhere.OR = [
-        { name:    { contains: keyword, mode: 'insensitive' } },
+        { name: { contains: keyword, mode: 'insensitive' } },
         { content: { contains: keyword, mode: 'insensitive' } },
       ];
     }
 
-    // 2) pointOrder가 없는 경우: Study 단일 쿼리 (recentOrder로만 정렬)
-    if (pointOrder !== 'asc' && pointOrder !== 'desc') {
-      const recentOrderBy = (recentOrder === 'old') ? { createdAt: 'asc' } : { createdAt: 'desc' };
+    // ───────────────────────────────────────────────────
+    // A. 시간 정렬: recent/old → createdAt 단일 정렬
+    // ───────────────────────────────────────────────────
+    if (sort === 'recent' || sort === 'old') {
+      const orderBy =
+        sort === 'old' ? { createdAt: 'asc' } : { createdAt: 'desc' };
 
-      const studiesPromise = prisma.study.findMany({
-        where: studyWhere,
-        orderBy: [recentOrderBy],
-        skip: offset,
-        take: (limit < 50 ? limit : 50),
-        select: {
-          id: true, nick: true, name: true, content: true, img: true,
-          isActive: true, createdAt: true, updatedAt: true,
-          studyEmojis: {
-            orderBy: [{ count: 'desc' }, { emojiId: 'asc' }],
-            take: 3,
-            select: { count: true, emoji: { select: { id: true, symbol: true } } },
+      const [rows, totalCount] = await Promise.all([
+        prisma.study.findMany({
+          where: studyWhere,
+          orderBy: [orderBy],
+          skip: offset,
+          take: limit < 50 ? limit : 50,
+          select: {
+            id: true,
+            nick: true,
+            name: true,
+            content: true,
+            img: true,
+            isActive: true,
+            createdAt: true,
+            updatedAt: true,
+            studyEmojis: {
+              orderBy: [{ count: 'desc' }, { emojiId: 'asc' }],
+              take: 3,
+              select: {
+                count: true,
+                emoji: { select: { id: true, symbol: true } },
+              },
+            },
           },
-        },
-      });
+        }),
+        prisma.study.count({ where: studyWhere }),
+      ]);
 
-      const totalCountPromise = prisma.study.count({ where: studyWhere });
-      const results = await Promise.all([studiesPromise, totalCountPromise]);
-
-      // ✅ point 총합 보강 (_sum.point)
-      const studies = results[0];
-      const totalCount = results[1];
-
-      const ids = studies.map(s => s.id);
+      // 총합 포인트(point) 보강
+      const ids = rows.map(s => s.id);
       let sumMap = new Map();
       if (ids.length > 0) {
-        const sumRows = await prisma.point.groupBy({
+        const sums = await prisma.point.groupBy({
           by: ['studyId'],
           where: { studyId: { in: ids } },
-          _sum: { point: true }, // ← 합계 기준: point
+          _sum: { point: true },
         });
         sumMap = new Map(
-          sumRows.map(r => {
-            const val = (r._sum && typeof r._sum.point === 'number') ? r._sum.point : 0;
+          sums.map(r => {
+            const val =
+              r._sum && typeof r._sum.point === 'number' ? r._sum.point : 0;
             return [r.studyId, val];
-          })
+          }),
         );
       }
-
-      const enriched = studies.map(s => {
+      const enriched = rows.map(s => {
         const sum = sumMap.has(s.id) ? sumMap.get(s.id) : 0;
-        // 응답 키 이름을 명확히: 총합 포인트 = point
-        return Object.assign({}, s, { point: sum });
+        return { ...s, point: sum };
       });
 
       return { studies: enriched, totalCount };
     }
 
-    // 3) pointOrder가 있는 경우:
-    //    1단계) 포인트가 있는 스터디를 point 합계로 정렬해서 페이지 자르기
-    const groupPage = await prisma.point.groupBy({
+    // ───────────────────────────────────────────────────
+    // B. 포인트 정렬: points_desc/points_asc
+    //    Prisma 6.15 제약으로 relation-aggregate orderBy 미지원 → groupBy 우회
+    // ───────────────────────────────────────────────────
+    const pointOrder = sort === 'points_asc' ? 'asc' : 'desc';
+
+    // 1단계: 포인트가 있는 스터디를 point 합계로 정렬하여 페이지 자르기
+    const page = await prisma.point.groupBy({
       by: ['studyId'],
-      where: { study: studyWhere },      // isActive/keyword 반영
-      _sum: { point: true },             // ← 합계 기준: point
+      where: { study: studyWhere },
+      _sum: { point: true },
       orderBy: { _sum: { point: pointOrder } },
       skip: offset,
-      take: (limit < 50 ? limit : 50),
+      take: limit < 50 ? limit : 50,
     });
+    const orderedIds = page.map(r => r.studyId);
 
-    const orderedIds = groupPage.map(r => r.studyId);
-
-    // 4) 1단계 id들로 Study 조회 (순서 재구성)
+    // 2단계: 해당 Study 조회(순서 복원)
     let groupRows = [];
     if (orderedIds.length > 0) {
       const rows = await prisma.study.findMany({
-        where: { id: { in: orderedIds } },    // studyWhere는 이미 groupBy에서 필터됨
+        where: { id: { in: orderedIds } }, // groupBy에 studyWhere 이미 반영됨
         select: {
-          id: true, nick: true, name: true, content: true, img: true,
-          isActive: true, createdAt: true, updatedAt: true,
+          id: true,
+          nick: true,
+          name: true,
+          content: true,
+          img: true,
+          isActive: true,
+          createdAt: true,
+          updatedAt: true,
           studyEmojis: {
             orderBy: [{ count: 'desc' }, { emojiId: 'asc' }],
             take: 3,
-            select: { count: true, emoji: { select: { id: true, symbol: true } } },
+            select: {
+              count: true,
+              emoji: { select: { id: true, symbol: true } },
+            },
           },
         },
       });
       const map = new Map(rows.map(r => [r.id, r]));
-      groupRows = orderedIds.map(id => map.get(id)).filter(v => Boolean(v)); // groupBy 순서 보존
+      groupRows = orderedIds.map(id => map.get(id)).filter(Boolean);
     }
 
-    // 5) 보강: limit가 모자라면 포인트 없는(=집계에 안 잡힌) 스터디를 recentOrder 기준으로 채움
+    // 3단계: 페이지 부족 시 포인트 0 스터디 보강(정렬 1가지만 유지 → 단순 take)
     const deficit = limit - groupRows.length;
     let fillerRows = [];
     if (deficit > 0) {
       const notIn = orderedIds.length > 0 ? { notIn: orderedIds } : undefined;
-      const recentOrderBy = (recentOrder === 'old') ? { createdAt: 'asc' } : { createdAt: 'desc' };
-
-      const whereFiller = Object.assign({}, studyWhere);
+      const whereFiller = { ...studyWhere };
       if (notIn) whereFiller.id = notIn;
 
       fillerRows = await prisma.study.findMany({
         where: whereFiller,
-        orderBy: [recentOrderBy],
         take: deficit,
         select: {
-          id: true, nick: true, name: true, content: true, img: true,
-          isActive: true, createdAt: true, updatedAt: true,
+          id: true,
+          nick: true,
+          name: true,
+          content: true,
+          img: true,
+          isActive: true,
+          createdAt: true,
+          updatedAt: true,
           studyEmojis: {
             orderBy: [{ count: 'desc' }, { emojiId: 'asc' }],
             take: 3,
-            select: { count: true, emoji: { select: { id: true, symbol: true } } },
+            select: {
+              count: true,
+              emoji: { select: { id: true, symbol: true } },
+            },
           },
         },
       });
     }
 
-    // 6) 최종 합치기
-    const studies = groupRows.concat(fillerRows);
+    // 합치기
+    let merged = groupRows.concat(fillerRows);
 
-    // ✅ point 총합 보강 (_sum.point) — 최종 id 집합으로 한 번에
-    const ids = studies.map(s => s.id);
+    // 총합 포인트 매핑
+    const ids = merged.map(s => s.id);
     let sumMap = new Map();
     if (ids.length > 0) {
-      const sumRows = await prisma.point.groupBy({
+      const sums = await prisma.point.groupBy({
         by: ['studyId'],
         where: { studyId: { in: ids } },
-        _sum: { point: true }, // ← 합계 기준: point
+        _sum: { point: true },
       });
       sumMap = new Map(
-        sumRows.map(r => {
-          const val = (r._sum && typeof r._sum.point === 'number') ? r._sum.point : 0;
+        sums.map(r => {
+          const val =
+            // eslint-disable-next-line no-underscore-dangle
+            r._sum && typeof r._sum.point === 'number' ? r._sum.point : 0;
           return [r.studyId, val];
-        })
+        }),
       );
     }
-    const enriched = studies.map(s => {
+    merged = merged.map(s => {
       const sum = sumMap.has(s.id) ? sumMap.get(s.id) : 0;
-      return Object.assign({}, s, { point: sum });
+      return { ...s, point: sum };
     });
 
-    // 7) totalCount는 Study 전체 수(where 기준)
-    const totalCount = await prisma.study.count({ where: studyWhere });
+    // 최종 정렬: 포인트 단일 정렬만 적용(충돌 방지)
+    const dir = pointOrder === 'asc' ? 1 : -1;
+    merged = merged.sort((a, b) => {
+      const pa = typeof a.point === 'number' ? a.point : 0;
+      const pb = typeof b.point === 'number' ? b.point : 0;
+      if (pa === pb) return 0;
+      return (pa - pb) * dir;
+    });
 
-    return { studies: enriched, totalCount };
+    const totalCount = await prisma.study.count({ where: studyWhere });
+    return { studies: merged, totalCount };
   } catch (error) {
     console.log(error, '가 발생했습니다.');
     throw error;
@@ -246,7 +289,7 @@ async function serviceStudyUpdate(
   img,
   password,
   isActive,
-){
+) {
   try {
     // studyId에 해당하는 스터디의 해시된 비밀번호를 DB에서 조회
     const study = await prisma.study.findUnique({
@@ -365,9 +408,7 @@ async function serviceStudyDetail(studyId) {
 
     // ✅ 안전 접근(?? 미사용): _sum 또는 point가 없으면 0
     const totalPoint =
-      pointsAgg &&
-      pointsAgg._sum &&
-      typeof pointsAgg._sum.point === 'number'
+      pointsAgg && pointsAgg._sum && typeof pointsAgg._sum.point === 'number'
         ? pointsAgg._sum.point
         : 0;
 
@@ -454,7 +495,9 @@ async function serviceEmojiIncrement(studyId, emojiSymbol, emojiCount) {
     }
     if (err.code === 'P2003') {
       // FK 위반: Study가 실제로 존재하는지 확인 필요
-      const e = new Error(`FK 위반(P2003): Study(${sid}) 또는 Emoji(${eid})가 존재하지 않습니다.`);
+      const e = new Error(
+        `FK 위반(P2003): Study(${sid}) 또는 Emoji(${eid})가 존재하지 않습니다.`,
+      );
       e.code = 'FK_VIOLATION';
       throw e;
     }
@@ -478,7 +521,13 @@ async function serviceEmojiDecrement(studyId, emojiSymbol, emojiCount) {
 
   // 이모지 자체가 없으면 감소할 대상이 없으므로 종료
   if (!emoji) {
-    return { deleted: false, studyId: sid, emojiId: null, count: 0, reason: 'emoji-not-found' };
+    return {
+      deleted: false,
+      studyId: sid,
+      emojiId: null,
+      count: 0,
+      reason: 'emoji-not-found',
+    };
   }
 
   const eid = emoji.id;
@@ -504,7 +553,13 @@ async function serviceEmojiDecrement(studyId, emojiSymbol, emojiCount) {
 
   if (!current) {
     // 해당 이모지 카운트 자체가 없었음
-    return { deleted: false, studyId: sid, emojiId: eid, count: 0, reason: 'not-exists' };
+    return {
+      deleted: false,
+      studyId: sid,
+      emojiId: eid,
+      count: 0,
+      reason: 'not-exists',
+    };
   }
 
   // 4) 기존 count <= dec 이면 0 이하가 되므로 삭제
@@ -517,7 +572,13 @@ async function serviceEmojiDecrement(studyId, emojiSymbol, emojiCount) {
   }
 
   // 동시성 등으로 이미 삭제된 케이스
-  return { deleted: false, studyId: sid, emojiId: eid, count: 0, reason: 'race' };
+  return {
+    deleted: false,
+    studyId: sid,
+    emojiId: eid,
+    count: 0,
+    reason: 'race',
+  };
 }
 
 export default {


### PR DESCRIPTION
- serviceStudyList()에서 포인트/생성 순 정렬에 관한 문제 수정
- controlStudyList()에서 쿼리파라미터 파싱관련 로직 변경
- 사용방법
  - 드롭다운 선택 시 sort에 recent | old | points_desc | points_asc 중 하나만 넣어 호출
  - 예시) /api/studies?sort=recent&isActive=true&offset=0&limit=6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 스터디 목록에 총 개수(totalCount) 제공.
  - 정렬 옵션을 단일 파라미터로 통합: 최신순/오래된순/포인트 오름차순/내림차순 지원.
- Bug Fixes
  - 검색어·활성화 상태 파라미터 처리 안정화(불리언/공백 등).
- Refactor
  - 기본값 조정: 활성화 여부 기본 활성(true), 기본 검색어 공백.
  - 목록 조회 한도 상한 50으로 제한.
  - 요청 형식 변경: 기존 정렬 관련 두 파라미터를 하나로 통합(호환성 주의).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->