### PR TITLE
hotfix: 오늘의 집중 API 수정/삭제

### DIFF
--- a/http/focus.http
+++ b/http/focus.http
@@ -24,6 +24,5 @@ PATCH {{base_prod}}/focus/{{studyId}}
 Content-Type: application/json
 
 {
-  "minuteData": 10,
-  "secondData": 0
+  "totalPoints": 50
 }

--- a/http/focus.http
+++ b/http/focus.http
@@ -16,8 +16,7 @@ PATCH {{base_local}}/focus/{{studyId}}
 Content-Type: application/json
 
 {
-  "minuteData": 10,
-  "secondData": 0
+  "totalPoints": 50
 }
 
 ### 2) [배포] 오늘의 집중 수정 API

--- a/src/api/controllers/focus.controllers.js
+++ b/src/api/controllers/focus.controllers.js
@@ -1,86 +1,25 @@
 // 요청 파싱(params/query/body) + 입력 검증 결과 처리
-import { PrismaClient } from '@prisma/client';
 // eslint-disable-next-line import/extensions
 import focusService from '../services/focus.services.js';
 
-const prisma = new PrismaClient();
-
-async function controlGetList(req, res) {
-  /* 파라미터/바디 파싱 및 입력 검증 */
-  const studyId = Number(req.params.studyId);
-  if (!Number.isInteger(studyId) || studyId <= 0) {
-    const err = new Error('유효하지 않은 스터디 ID입니다.');
-    err.status = 400;
-    err.code = 'INVALID_STUDY_ID';
-    throw err;
-  }
-
-  const studyIdResult = await prisma.study.findUnique({
-    where: { id: studyId },
-    select: { id: true },
-  });
-  if (!studyIdResult) {
-    const err = new Error('존재하지 않는 스터디 ID입니다.');
-    err.status = 404;
-    err.code = 'STUDY_NOT_FOUND';
-    throw err;
-  }
-
-  /* 서비스 호출 */
-  const focusList = await focusService.serviceGetList(studyId);
-
-  /* 결과 반환 */
-  res.status(200).json(focusList);
-}
-
 async function controlUpdateFocus(req, res) {
   /* 파라미터/바디 파싱 및 입력 검증 */
-  const studyId = Number(req.params.studyId);
-  if (!Number.isInteger(studyId) || studyId <= 0) {
-    const err = new Error('유효하지 않은 스터디 ID입니다.');
-    err.status = 400;
-    err.code = 'INVALID_STUDY_ID';
-    throw err;
-  }
-  const studyIdResult = await prisma.study.findUnique({
-    where: { id: studyId },
-    select: { id: true },
-  });
-  if (!studyIdResult) {
-    const err = new Error('존재하지 않는 스터디 ID입니다.');
-    err.status = 404;
-    err.code = 'STUDY_NOT_FOUND';
-    throw err;
-  }
+  const { studyId } = req.params;
 
-  const minuteData = Number(req.body?.minuteData);
-  const secondData = Number(req.body?.secondData);
-  if (
-    !Number.isInteger(minuteData) ||
-    !Number.isInteger(secondData) ||
-    minuteData < 0 ||
-    secondData < 0 ||
-    secondData > 59 ||
-    (minuteData === 0 && secondData === 0)
-  ) {
-    const err = new Error('유효하지 않은 시간 데이터입니다.');
-    err.status = 400;
-    err.code = 'INVALID_TIME_DATA';
-    throw err;
+  const points = Number(req.body.totalPoints);
+  if (!points || points < 0) {
+    const error = new Error('point 값은 0 이상의 숫자여야 합니다.');
+    error.status = 400;
+    throw error;
   }
 
   /* 서비스 호출 */
-  const focusResult = await focusService.serviceUpdateFocus(
-    studyId,
-    minuteData,
-    secondData,
-  );
+  const focusResult = await focusService.serviceUpdateFocus(points, studyId);
 
   /* 결과 반환 */
   res.status(200).json(focusResult);
 }
 
 export default {
-  controlGetList,
   controlUpdateFocus,
 };

--- a/src/api/controllers/focus.controllers.js
+++ b/src/api/controllers/focus.controllers.js
@@ -4,12 +4,19 @@ import focusService from '../services/focus.services.js';
 
 async function controlUpdateFocus(req, res) {
   /* 파라미터/바디 파싱 및 입력 검증 */
-  const { studyId } = req.params;
+  const studyId = Number(req.params.studyId);
+  if (!Number.isFinite(studyId) || studyId <= 0) {
+    const error = new Error('유효하지 않은 studyId 입니다.');
+    error.status = 400;
+    error.code = 'INVALID_STUDY_ID';
+    throw error;
+  }
 
   const points = Number(req.body.totalPoints);
-  if (!points || points < 0) {
+  if (!Number.isFinite(points) || points < 0) {
     const error = new Error('point 값은 0 이상의 숫자여야 합니다.');
     error.status = 400;
+    error.code = 'INVALID_POINTS';
     throw error;
   }
 

--- a/src/api/routes/focus.routes.js
+++ b/src/api/routes/focus.routes.js
@@ -22,46 +22,15 @@ router.use(coreMiddleware); // CORS 미들웨어 적용
 /**
  * @swagger
  * /api/focus/{studyId}:
- *   get:
- *     summary: 스터디별 집중 시간 목록 조회
- *     tags: [Focus]
- *     parameters:
- *       - in: path
- *         name: studyId
- *         required: true
- *         schema:
- *           type: integer
- *           example: 1
- *         description: 스터디 ID
- *     responses:
- *       200:
- *         description: 성공적으로 조회됨
- *         content:
- *           application/json:
- *             schema:
- *               type: array
- *               items:
- *                 type: object
- *                 properties:
- *                   id:
- *                     type: integer
- *                     example: 1
- *                   setTime:
- *                     type: string
- *                     format: date-time
- *                     example: "2025-09-11T23:41:08.354Z"
- *       400:
- *         description: 잘못된 스터디 ID
- *       404:
- *         description: 존재하지 않는 스터디
- *
  *   patch:
- *     summary: 스터디 집중 시간 갱신
+ *     summary: 스터디 포인트 갱신
+ *     description: 특정 스터디의 포인트를 누적 갱신합니다.
  *     tags: [Focus]
  *     parameters:
  *       - in: path
  *         name: studyId
  *         required: true
+ *         description: 포인트를 갱신할 스터디 ID
  *         schema:
  *           type: integer
  *           example: 1
@@ -72,56 +41,30 @@ router.use(coreMiddleware); // CORS 미들웨어 적용
  *           schema:
  *             type: object
  *             required:
- *               - minuteData
- *               - secondData
+ *               - totalPoints
  *             properties:
- *               minuteData:
+ *               totalPoints:
  *                 type: integer
  *                 minimum: 0
- *                 description: 분 단위 (0 이상)
- *                 example: 10
- *               secondData:
- *                 type: integer
- *                 minimum: 0
- *                 maximum: 59
- *                 description: 초 단위 (0 이상 59 이하)
- *                 example: 30
+ *                 description: 누적할 포인트 값 (0 이상)
+ *                 example: 50
  *     responses:
  *       200:
- *         description: 성공적으로 업데이트됨
+ *         description: 포인트 갱신 성공
  *         content:
  *           application/json:
  *             schema:
  *               type: object
  *               properties:
- *                 id:
+ *                 point:
  *                   type: integer
- *                   example: 2
- *                 setTime:
- *                   type: string
- *                   format: date-time
- *                   example: "2025-09-10T02:29:29.866Z"
- *                 createdAt:
- *                   type: string
- *                   format: date-time
- *                   example: "2025-09-09T01:14:31.143Z"
- *                 updatedAt:
- *                   type: string
- *                   format: date-time
- *                   example: "2025-09-10T02:19:29.866Z"
- *                 studyId:
- *                   type: integer
- *                   example: 1
+ *                   description: 갱신 후 누적 포인트
+ *                   example: 795
  *       400:
- *         description: 유효하지 않은 입력값
+ *         description: 잘못된 요청 (point 값이 0 미만이거나 형식 오류)
  *       404:
- *         description: 존재하지 않는 스터디
+ *         description: 해당 studyId에 대한 포인트 정보 없음
  */
-
-router.get(
-  '/:studyId',
-  errorMiddleware.asyncHandler(focusControllers.controlGetList),
-);
 
 router.patch(
   '/:studyId',

--- a/src/api/services/focus.services.js
+++ b/src/api/services/focus.services.js
@@ -2,62 +2,26 @@ import { PrismaClient } from '@prisma/client';
 
 const prisma = new PrismaClient();
 
-async function serviceGetList(studyId) {
-  const focusList = await prisma.focus.findMany({
-    where: { studyId },
-    select: {
-      id: true,
-      setTime: true,
-    },
+async function serviceUpdateFocus(point, studyId) {
+  const updateResult = await prisma.point.updateMany({
+    where: { studyId: Number(studyId) },
+    data: { point: { increment: point } },
   });
 
-  if (focusList.length === 0) {
-    return [];
+  if (updateResult.count === 0) {
+    const error = new Error(
+      `studyId ${studyId}에 해당하는 포인트 기록이 없습니다.`,
+    );
+    error.status = 404;
+    throw error;
   }
 
-  return focusList;
-}
-
-async function serviceUpdateFocus(studyId, minuteData, secondData) {
-  // ms 변환 헬퍼
-  const toMs = (minutes = 0, seconds = 0) => (minutes * 60 + seconds) * 1000;
-
-  // 의도: 오늘 행을 찾아 setTime = setTime + time (DateTime)
-  const today0 = new Date();
-  today0.setHours(0, 0, 0, 0);
-  const today1 = new Date();
-  today1.setHours(23, 59, 59, 999);
-
-  // 1) 오늘 행 찾기 (가장 최근 1건 가정)
-  const current = await prisma.focus.findFirst({
-    where: { studyId, setTime: { gte: today0, lte: today1 } },
-    orderBy: { id: 'desc' },
+  return prisma.point.findFirst({
+    where: { studyId: Number(studyId) },
+    select: { point: true },
   });
-
-  const now = new Date();
-  if (!current) {
-    // 오늘 행이 없으면 새로 생성
-    const created = await prisma.focus.create({
-      data: {
-        studyId,
-        setTime: new Date(now.getTime() + toMs(minuteData, secondData)), // 초기값을 “현재+delta”로
-        createdAt: now,
-        updatedAt: now,
-      },
-    });
-    return created;
-  }
-
-  // 2) 존재하면 Date 계산 후 대체 업데이트
-  const newSetTime = new Date(now.getTime() + toMs(minuteData, secondData));
-  const updated = await prisma.focus.update({
-    where: { id: current.id }, // ✅ focus PK로 갱신
-    data: { setTime: newSetTime, updatedAt: now },
-  });
-  return updated;
 }
 
 export default {
-  serviceGetList,
   serviceUpdateFocus,
 };


### PR DESCRIPTION
- 오늘의 집중 목록 API 삭제
- 포인트 업데이트 API 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - 집중 시간 기반에서 포인트 누적 방식으로 전환: PATCH /api/focus/{studyId} 요청 본문이 minuteData/secondData에서 totalPoints(정수, 0 이상)로 변경되고, 응답은 갱신 후의 누적 point만 반환합니다.
  - 기존 GET /api/focus/{studyId} 목록 조회 엔드포인트 제거.

- Documentation
  - Swagger 문서를 최신 스펙으로 갱신: 경로·요청·응답 스키마 및 400/404 오류 설명을 한국어로 업데이트.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->