### PR TITLE
hotfix: focus필드 삭제에 따른 seed.js 수정 및 코드 리뷰 반영

### DIFF
--- a/src/api/services/habit.services.js
+++ b/src/api/services/habit.services.js
@@ -245,6 +245,14 @@ export async function toggleHabitService({ habitId, password }) {
   });
 
   // 3) 토글
+  const { startUtc, endUtc } = getKSTDayRange();
+  const isTodayKST = target.date >= startUtc && target.date < endUtc;
+  if (!isTodayKST) {
+    const e = new Error('오늘 기록만 체크/해제할 수 있습니다.');
+    e.name = 'BadRequestError';
+    e.status = 400;
+    throw e;
+  }
   const updated = await prisma.habit.update({
     where: { id: habitId },
     data: { isDone: !target.isDone },

--- a/src/prisma/seed.js
+++ b/src/prisma/seed.js
@@ -213,10 +213,6 @@ async function seedPerStudy(study, emojis) {
       ],
     });
 
-    await tx.focus.create({
-      data: { setTime: faker.date.soon({ days: 3 }), studyId: study.id },
-    });
-
     await tx.point.create({
       data: {
         point: faker.number.int({ min: 5, max: 300 }),
@@ -278,10 +274,6 @@ async function createTestStudy(emojis, customHabits = []) {
       date: new Date(baseDate.getTime() - i * 24 * 60 * 60 * 1000), // 날짜 분산
       habitHistoryId: habitHistory.id,
     })),
-  });
-
-  await prisma.focus.create({
-    data: { setTime: faker.date.soon({ days: 3 }), studyId: study.id },
   });
 
   const awarded = faker.number.int({ min: 5, max: 300 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 새로운 동작 변경
  - KST 기준 ‘오늘’ 기록에만 습관 체크/해제가 가능해졌습니다. 오늘이 아닌 날짜에 시도하면 400 오류와 안내 메시지가 표시됩니다.
  - 체크/해제 후 해당 날짜의 일별 요약(요일별 진행 상태)을 자동으로 재계산해 반영합니다.
  - 오늘 습관 처리 시 경계(시작/종료 시각) 검사 로직을 강화했습니다.
  - 중복 생성 오류 발생 시 HTTP 409 상태를 반환합니다.
- Chores
  - 시드 데이터에서 일부 스터디의 Focus 항목 생성을 제거해 초기 데이터 구성을 간소화했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->