### PR TITLE
feat: 로컬 개발 환경에 새로운 CORS 허용 출처 추가

### DIFF
--- a/src/common/cors.js
+++ b/src/common/cors.js
@@ -10,6 +10,7 @@ const corsOptions = {
     'https://eight-studyforest-team2-be.onrender.com',
     'http://localhost:3000',
     'http://localhost:5173',
+    'http://localhost:4173',
     'https://mindmeld-fe.vercel.app',
     'https://8-study-forest-team2-fe-git-develop-seongeun95s-projects.vercel.app',
     'https://8-study-forest-team2-ccu0vb250-seongeun95s-projects.vercel.app',


### PR DESCRIPTION
- 프론트 cors 허용 출처 추가

'http://localhost:4173'

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 버그 수정
  * 로컬 개발/미리보기 환경(포트 4173)에서 API 접근이 차단되던 현상을 해소했습니다. 브라우저 콘솔의 CORS 오류가 감소하고, 페이지 로드와 폼 제출·데이터 조회 등 네트워크 기능이 안정적으로 동작합니다.
* 잡무
  * 허용된 도메인 범위를 확대해 로컬 테스트 및 프리뷰 툴과의 연결성을 개선했습니다. 기존 프로덕션 동작에는 영향이 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->