### PR TITLE
fix: 코드 리뷰 반영

### DIFF
--- a/src/api/services/habit.services.js
+++ b/src/api/services/habit.services.js
@@ -386,59 +386,69 @@ export async function renameTodayHabitService({
   await assertStudyWithPassword({ studyId, password });
   const { startUtc, endUtc } = getKSTDayRange(); // 오늘 24:00(KST) 기준
 
-  return await prisma.$transaction(async tx => {
-    // 1) 오늘 습관(=기준 습관) 찾기 + 소속 검증
-    const base = await tx.habit.findFirst({
-      where: {
-        id: habitId,
-        date: { gte: startUtc, lt: endUtc }, // 오늘(포함) 레코드여야 함
-        habitHistory: { is: { studyId } },
-      },
-      select: { id: true, habit: true, habitHistoryId: true, date: true },
-    });
-    if (!base) {
-      const e = new Error('해당 습관을 찾을 수 없습니다(오늘 기록이 아님).');
-      e.name = 'NotFoundError';
-      throw e;
-    }
+  try {
+    return await prisma.$transaction(async tx => {
+      // 1) 오늘 습관(=기준 습관) 찾기 + 소속 검증
+      const base = await tx.habit.findFirst({
+        where: {
+          id: habitId,
+          date: { gte: startUtc, lt: endUtc }, // 오늘(포함) 레코드여야 함
+          habitHistory: { is: { studyId } },
+        },
+        select: { id: true, habit: true, habitHistoryId: true, date: true },
+      });
+      if (!base) {
+        const e = new Error('해당 습관을 찾을 수 없습니다(오늘 기록이 아님).');
+        e.name = 'NotFoundError';
+        throw e;
+      }
 
-    // 2) 충돌 검사
-    const conflicts = await tx.habit.findMany({
-      where: {
-        habitHistoryId: base.habitHistoryId,
-        habit: newTitle,
-        date: { gte: startUtc, lt: endUtc },
-      },
-      select: { id: true, date: true },
+      // 2) 충돌 검사
+      const conflicts = await tx.habit.findMany({
+        where: {
+          habitHistoryId: base.habitHistoryId,
+          habit: newTitle,
+          date: { gte: startUtc, lt: endUtc },
+        },
+        select: { id: true, date: true },
+      });
+      if (conflicts.length > 0) {
+        const e = new Error('동일 날짜에 같은 이름의 습관이 이미 존재합니다.');
+        e.name = 'ConflictError';
+        e.conflicts = conflicts.map(c => c.date);
+        throw e;
+      }
+
+      // 3) 변경 대상 조회
+      const targets = await tx.habit.findMany({
+        where: {
+          habitHistoryId: base.habitHistoryId,
+          habit: base.habit,
+          date: { gte: startUtc, lt: endUtc },
+        },
+        select: { id: true },
+      });
+      if (targets.length === 0) {
+        return { updated: 0, newTitle };
+      }
+
+      // 4) 일괄 변경
+      const updated = await tx.habit.updateMany({
+        where: { id: { in: targets.map(t => t.id) } },
+        data: { habit: newTitle },
+      });
+
+      return { updated: updated.count, newTitle };
     });
-    if (conflicts.length > 0) {
+  } catch (err) {
+    if (err?.code === 'P2002') {
       const e = new Error('동일 날짜에 같은 이름의 습관이 이미 존재합니다.');
       e.name = 'ConflictError';
-      e.conflicts = conflicts.map(c => c.date);
+      e.status = 409;
       throw e;
     }
-
-    // 3) 변경 대상 조회
-    const targets = await tx.habit.findMany({
-      where: {
-        habitHistoryId: base.habitHistoryId,
-        habit: base.habit,
-        date: { gte: startUtc, lt: endUtc },
-      },
-      select: { id: true },
-    });
-    if (targets.length === 0) {
-      return { updated: 0, newTitle };
-    }
-
-    // 4) 일괄 변경
-    const updated = await tx.habit.updateMany({
-      where: { id: { in: targets.map(t => t.id) } },
-      data: { habit: newTitle },
-    });
-
-    return { updated: updated.count, newTitle };
-  });
+    throw err;
+  }
 }
 
 // 오늘의 습관 삭제
@@ -537,14 +547,11 @@ export async function addTodayHabitService({ studyId, password, title }) {
       if (err?.code === 'P2002') {
         const e = new Error('오늘 이미 같은 이름의 습관이 존재합니다.');
         e.name = 'ConflictError';
-
         e.status = 409;
-
         throw e;
       }
       throw err;
     }
-
     return {
       created: {
         habitId: created.id,

--- a/src/api/services/habit.services.js
+++ b/src/api/services/habit.services.js
@@ -404,10 +404,15 @@ export async function renameTodayHabitService({
       }
 
       // 2) 충돌 검사
+      const normalizedNew = newTitle.trim();
+      // 동일 값이면 갱신 없이 성공 처리
+      if (normalizedNew === base.habit) {
+        return { updated: 0, newTitle: base.habit };
+      }
       const conflicts = await tx.habit.findMany({
         where: {
           habitHistoryId: base.habitHistoryId,
-          habit: newTitle,
+          habit: normalizedNew,
           date: { gte: startUtc, lt: endUtc },
         },
         select: { id: true, date: true },
@@ -435,7 +440,7 @@ export async function renameTodayHabitService({
       // 4) 일괄 변경
       const updated = await tx.habit.updateMany({
         where: { id: { in: targets.map(t => t.id) } },
-        data: { habit: newTitle },
+        data: { habit: normalizedNew },
       });
 
       return { updated: updated.count, newTitle };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 오늘의 습관 이름 변경 시 동일 날짜 내 중복 이름을 정확히 감지하고 일관된 충돌 오류(409)로 안내합니다.
  * 존재하지 않는 항목에 대한 이름 변경 요청 시 명확한 “찾을 수 없음” 오류를 제공합니다.
  * 변경 처리의 안정성을 개선해 간헐적 실패 및 불명확한 오류를 줄였습니다.
  * 성공 시 반환 형식과 동작은 기존과 동일하게 유지됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->