### PR TITLE
fix: 오늘의 습관 조회할때만  비밀번호 입력하는 동작으로 변경 완료

### DIFF
--- a/http/habit.http
+++ b/http/habit.http
@@ -1,9 +1,9 @@
 # 오늘의 습관 API를 테스트하는 HTTP 요청 파일입니다.
 // 로컬 시드 데이터를 기준으로 테스트 http 요청
 @base = http://localhost:3000/api
-@studyId = 36
-@habbitId = 32
-@pwd = 1234
+@studyId = 1
+@habitId = 6
+@pwd = abcd1234
 @date = 2025-09-02
 
 ### 1) 오늘의 습관 조회 (지금 해본 것)
@@ -13,24 +13,21 @@ x-study-password: {{pwd}}
 ### 2) 오늘의 습관 일괄 생성 (여기서 실제 생성됨)
 POST {{base}}/habits/today/{{studyId}}/bulk
 Content-Type: application/json
-x-study-password: {{pwd}}
-
 {
   "habits": ["물 1리터 마시기", "운동 30분", "회고 쓰기"]
 }
 
 ### 3) 체크/해제 (토글) — 생성 후 응답/조회에서 받은 habitId로 바꿔서 실행
 PATCH {{base}}/habits/{{habitId}}/toggle
-x-study-password: {{pwd}}
 
 ### 4) 주간 기록 조회 (해당 날짜가 속한 주)
 GET {{base}}/habits/week/{{studyId}}?date={{date}}
-x-study-password: {{pwd}}
+
 
 ### 5) 오늘의 습관 단일 생성
 POST {{base}}/habits/today/{{studyId}}
 Content-Type: application/json
-x-study-password: {{pwd}}
+
 
 {
   "title": "단어 50개"
@@ -40,7 +37,7 @@ x-study-password: {{pwd}}
 @renameHabitId = 15
 PATCH {{base}}/habits/today/{{studyId}}/{{renameHabitId}}
 Content-Type: application/json
-x-study-password: {{pwd}}
+
 
 {
   "title": "단어 100개"

--- a/http/habit.http
+++ b/http/habit.http
@@ -33,7 +33,7 @@ Content-Type: application/json
   "title": "단어 50개"
 }
 
-### 6) 오늘의 습관 이름 변경 (오늘 포함 과거 전체 반영)
+### 6) 오늘의 습관 이름 변경 
 @renameHabitId = 15
 PATCH {{base}}/habits/today/{{studyId}}/{{renameHabitId}}
 Content-Type: application/json

--- a/src/api/controllers/habit.controllers.js
+++ b/src/api/controllers/habit.controllers.js
@@ -65,8 +65,6 @@ async function createTodayHabitsController(req, res, next) {
   try {
     const studyId = parsePositiveParam(req, 'studyId');
 
-    const password = parsePassword(req);
-
     let titles = [];
     if (Array.isArray(req.body?.habits)) {
       titles = req.body.habits.filter(
@@ -113,8 +111,6 @@ async function toggleHabitController(req, res, next) {
   try {
     const habitId = parsePositiveParam(req, 'habitId');
 
-    const password = parsePassword(req);
-
     const data = await toggleHabitService({ habitId, password });
     res.set('Cache-Control', 'no-store');
     res.vary('x-study-password');
@@ -138,8 +134,6 @@ async function getWeekHabitsController(req, res, next) {
   try {
     const studyId = parsePositiveParam(req, 'studyId');
 
-    const password = parsePassword(req);
-
     const dateStr =
       typeof req.query?.date === 'string' ? req.query.date : undefined;
 
@@ -162,7 +156,6 @@ async function getWeekHabitsController(req, res, next) {
 /* 오늘의 습관 이름 변경*/
 async function renameTodayHabitController(req, res) {
   const studyId = parsePositiveParam(req, 'studyId');
-  const password = parsePassword(req);
   const habitId = parsePositiveParam(req, 'habitId');
 
   const newTitle = String(req.body?.title || '').trim();
@@ -195,7 +188,6 @@ async function renameTodayHabitController(req, res) {
 /*오늘의 습관 삭제*/
 async function deleteTodayHabitController(req, res) {
   const studyId = parsePositiveParam(req, 'studyId');
-  const password = parsePassword(req);
   const habitId = parsePositiveParam(req, 'habitId');
 
   try {
@@ -221,7 +213,6 @@ async function deleteTodayHabitController(req, res) {
 /* 습관 단일 생성 */
 async function addTodayHabitController(req, res) {
   const studyId = parsePositiveParam(req, 'studyId');
-  const password = parsePassword(req);
   const title = String(req.body?.title || '').trim();
   if (!title) {
     return res.status(400).json({ message: 'title은 1자 이상이어야 합니다.' });

--- a/src/api/routes/habit.routes.js
+++ b/src/api/routes/habit.routes.js
@@ -131,8 +131,6 @@
  *     description: 문자열 배열을 오늘(KST 00:00) 날짜로 일괄 생성합니다. 이미 존재하는 항목은 스킵됩니다.
  *     parameters:
  *       - $ref: '#/components/parameters/StudyIdParam'
- *     security:
- *       - studyPassword: []
  *     requestBody:
  *       required: true
  *       content:
@@ -180,8 +178,6 @@
  *     description: 제목 하나를 오늘(KST 00:00) 날짜로 생성합니다. 같은 제목이 오늘 이미 있으면 409를 반환합니다.
  *     parameters:
  *       - $ref: '#/components/parameters/StudyIdParam'
- *     security:
- *       - studyPassword: []
  *     requestBody:
  *       required: true
  *       content:
@@ -222,8 +218,6 @@
  *         in: path
  *         required: true
  *         schema: { type: integer }
- *     security:
- *       - studyPassword: []
  *     responses:
  *       '200':
  *         description: 토글 성공
@@ -259,8 +253,6 @@
  *         required: false
  *         schema: { type: string, example: '2025-09-02' }
  *         description: 기준 날짜(YYYY-MM-DD). 미지정 시 오늘이 포함된 주.
- *     security:
- *       - studyPassword: []
  *     responses:
  *       '200':
  *         description: 조회 성공
@@ -324,8 +316,6 @@
  *         in: path
  *         required: true
  *         schema: { type: integer }
- *     security:
- *       - studyPassword: []
  *     requestBody:
  *       required: true
  *       content:
@@ -363,8 +353,6 @@
  *         in: path
  *         required: true
  *         schema: { type: integer }
- *     security:
- *       - studyPassword: []
  *     responses:
  *       '200':
  *         description: 삭제 성공

--- a/src/api/services/habit.services.js
+++ b/src/api/services/habit.services.js
@@ -244,7 +244,7 @@ export async function toggleHabitService({ habitId }) {
   }
 
   // 2) 스터디 인증
-  await assertStudyExists(studyId);
+  await assertStudyExists(target.habitHistory.studyId));
 
   // 3) 토글
   const { startUtc, endUtc } = getKSTDayRange();
@@ -302,7 +302,7 @@ export async function toggleHabitService({ habitId }) {
 
 /* GET 주간 습관 기록 조회 (KST 기준으로 days 키 통일) */
 export async function getWeekHabitsService({ studyId, dateStr }) {
-  const study = await assertStudyExists({ studyId });
+  const study = await assertStudyExists(studyId);
 
   const { weekStartUtc, weekEndUtc, weekDateOnly } = getKSTWeekRange(dateStr);
 
@@ -381,7 +381,6 @@ export async function getWeekHabitsService({ studyId, dateStr }) {
 // 오늘의 습관 이름 수정
 export async function renameTodayHabitService({
   studyId,
-
   habitId,
   newTitle,
 }) {

--- a/src/api/services/habit.services.js
+++ b/src/api/services/habit.services.js
@@ -244,7 +244,7 @@ export async function toggleHabitService({ habitId }) {
   }
 
   // 2) 스터디 인증
-  await assertStudyExists(target.habitHistory.studyId));
+  await assertStudyExists(target.habitHistory.studyId);
 
   // 3) 토글
   const { startUtc, endUtc } = getKSTDayRange();
@@ -379,11 +379,7 @@ export async function getWeekHabitsService({ studyId, dateStr }) {
   };
 }
 // 오늘의 습관 이름 수정
-export async function renameTodayHabitService({
-  studyId,
-  habitId,
-  newTitle,
-}) {
+export async function renameTodayHabitService({ studyId, habitId, newTitle }) {
   await assertStudyExists(studyId);
   const { startUtc, endUtc } = getKSTDayRange(); // 오늘 24:00(KST) 기준
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* 신기능
  * 습관 관련 작업에서 스터디 비밀번호 없이 이용 가능: 오늘 습관 일괄 생성/추가, 토글, 주간 조회, 이름 변경, 삭제.

* 문서
  * API 문서에서 해당 엔드포인트의 보안 요구사항(비밀번호) 제거 및 설명 갱신.

* 리팩터링
  * 내부 검증을 스터디 존재 여부 확인 방식으로 단순화하여 호출 흐름을 정리함.

* 테스트
  * HTTP 샘플 변수 및 인증 헤더 갱신(변수명 정리 및 불필요한 인증 헤더 제거).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->