### PR TITLE
fix: habit 컨트롤러 수정 오늘의 습관 조회할때만 비밀번호 요구하도록 변경

### DIFF
--- a/src/api/controllers/habit.controllers.js
+++ b/src/api/controllers/habit.controllers.js
@@ -82,9 +82,8 @@ async function createTodayHabitsController(req, res, next) {
       });
     }
 
-    const data = await createTodayHabitsService({ studyId, password, titles });
+    const data = await createTodayHabitsService({ studyId, titles });
     res.set('Cache-Control', 'no-store');
-    res.vary('x-study-password');
     return res.status(201).json(data);
   } catch (err) {
     if (err.name === 'UnauthorizedError') {
@@ -107,13 +106,12 @@ async function createTodayHabitsController(req, res, next) {
 
 /** 오늘의 습관 체크/해제 (토글) */
 
-async function toggleHabitController(req, res, next) {
+async function toggleHabitController(req, res) {
   try {
     const habitId = parsePositiveParam(req, 'habitId');
 
-    const data = await toggleHabitService({ habitId, password });
+    const data = await toggleHabitService({ habitId });
     res.set('Cache-Control', 'no-store');
-    res.vary('x-study-password');
     return res.json(data);
   } catch (err) {
     if (err.name === 'UnauthorizedError') {
@@ -130,16 +128,15 @@ async function toggleHabitController(req, res, next) {
 
 /* 주간 습관 기록 조회*/
 
-async function getWeekHabitsController(req, res, next) {
+async function getWeekHabitsController(req, res) {
   try {
     const studyId = parsePositiveParam(req, 'studyId');
 
     const dateStr =
       typeof req.query?.date === 'string' ? req.query.date : undefined;
 
-    const data = await getWeekHabitsService({ studyId, password, dateStr });
+    const data = await getWeekHabitsService({ studyId, dateStr });
     res.set('Cache-Control', 'no-store');
-    res.vary('x-study-password');
     return res.json(data);
   } catch (err) {
     if (err.name === 'UnauthorizedError') {
@@ -166,12 +163,10 @@ async function renameTodayHabitController(req, res) {
   try {
     const result = await renameTodayHabitService({
       studyId,
-      password,
       habitId,
       newTitle,
     });
     res.set('Cache-Control', 'no-store');
-    res.vary('x-study-password');
     return res.json(result);
   } catch (err) {
     if (err.name === 'UnauthorizedError')
@@ -193,11 +188,9 @@ async function deleteTodayHabitController(req, res) {
   try {
     const result = await deleteTodayHabitService({
       studyId,
-      password,
       habitId,
     });
     res.set('Cache-Control', 'no-store');
-    res.vary('x-study-password');
     return res.json(result);
   } catch (err) {
     if (err.name === 'UnauthorizedError')
@@ -219,9 +212,8 @@ async function addTodayHabitController(req, res) {
   }
 
   try {
-    const result = await addTodayHabitService({ studyId, password, title });
+    const result = await addTodayHabitService({ studyId, title });
     res.set('Cache-Control', 'no-store');
-    res.vary('x-study-password');
     return res.status(201).json(result);
   } catch (err) {
     if (err.name === 'UnauthorizedError')

--- a/src/api/controllers/habit.controllers.js
+++ b/src/api/controllers/habit.controllers.js
@@ -109,8 +109,8 @@ async function createTodayHabitsController(req, res, next) {
 async function toggleHabitController(req, res) {
   try {
     const habitId = parsePositiveParam(req, 'habitId');
-
-    const data = await toggleHabitService({ habitId });
+    const studyId = parsePositiveParam(req, 'studyId');
+    const data = await toggleHabitService({ studyId, habitId });
     res.set('Cache-Control', 'no-store');
     return res.json(data);
   } catch (err) {

--- a/src/api/services/habit.services.js
+++ b/src/api/services/habit.services.js
@@ -241,6 +241,12 @@ export async function toggleHabitService({ habitId }) {
     const e = new Error('해당 습관이 존재하지 않습니다.');
     e.name = 'NotFoundError';
     throw e;
+  } // 교차 검증: 경로의 studyId와 소속이 다르면 거부
+  if (studyId && target.habitHistory.studyId !== studyId) {
+    const e = new Error('잘못된 경로 파라미터입니다.');
+    e.name = 'BadRequestError';
+    e.status = 400;
+    throw e;
   }
 
   // 2) 스터디 인증


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * 습관 생성/토글/주간 보기/이름 변경/삭제/추가에서 스터디 비밀번호 입력이 더 이상 필요하지 않습니다.
  * 요청 헤더 요구사항이 단순화되었습니다(x-study-password 미사용). 민감 데이터 캐싱 방침(no-store)은 유지됩니다.
  * API 동작·오류 형식은 기존과 동일하게 유지되나, 경로의 스터디 식별자 불일치 시 400 응답이 발생할 수 있는 추가 검증이 도입되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->