### PR TITLE
docs: Swagger 문서 최신화

### DIFF
--- a/src/api/routes/study.routes.js
+++ b/src/api/routes/study.routes.js
@@ -68,13 +68,22 @@
  *         - $ref: '#/components/schemas/Study'
  *         - type: object
  *           properties:
- *             _count:
- *               type: object
- *               properties:
- *                 points: { type: integer, example: 12 }
- *                 habitHistories: { type: integer, example: 4 }
- *                 focuses: { type: integer, example: 7 }
- *                 studyEmojis: { type: integer, example: 3 }
+ *             studyEmojis:
+ *               type: array
+ *               description: 스터디 이모지 집계(카운트 내림차순, 동일 시 emojiId 오름차순)
+ *               items:
+ *                 type: object
+ *                 properties:
+ *                   count: { type: integer, minimum: 0, example: 9 }
+ *                   emoji:
+ *                     type: object
+ *                     properties:
+ *                       id: { type: integer, example: 1 }
+ *                       symbol: { type: string, example: 🔥 }
+ *              point:
+ *                type: integer
+ *                minimum: 0
+ *                description: 포인트 총합
  *
  *     StudyListResponse:
  *       type: object
@@ -100,11 +109,8 @@
  *             isActive: true
  *             createdAt: 2025-09-01T12:32:32.567Z
  *             updatedAt: 2025-09-01T12:32:32.567Z
- *             _count:
- *               points: 1
- *               habitHistories: 1
- *               focuses: 2
- *               studyEmojis: 1
+ *             studyEmojis: []
+ *             point: 0
  *         totalCount: 14
  *
  *     StudyDetail:

--- a/src/api/routes/study.routes.js
+++ b/src/api/routes/study.routes.js
@@ -445,46 +445,81 @@
  *   get:
  *     tags: [Studies]
  *     summary: 스터디 목록 조회
+ *     description: |
+ *       스터디 목록을 페이징으로 조회합니다.
+ *       - 정렬은 `sort` 파라미터 하나만 사용합니다. (`recent` | `old` | `points_desc` | `points_asc`)
+ *       - 하위 호환: `recentOrder`, `pointOrder`가 전달되면 내부적으로 `sort`로 매핑됩니다.
+ *       - 각 스터디 객체에는 이모지 상위 3개(`studyEmojis`)와 포인트 총합(`point`)이 포함됩니다.
  *     parameters:
  *       - in: query
  *         name: offset
- *         schema: { type: integer, minimum: 0 }
+ *         schema: { type: integer, minimum: 0, default: 0 }
  *         example: 0
+ *         description: 건너뛸 레코드 수
  *       - in: query
  *         name: limit
- *         schema: { type: integer, minimum: 1, maximum: 50 }
+ *         schema: { type: integer, minimum: 1, maximum: 50, default: 6 }
  *         example: 6
+ *         description: 최대 조회 건수
  *       - in: query
  *         name: keyword
  *         schema: { type: string }
  *         example: 알고리즘
+ *         description: 이름/내용 부분 일치 검색
  *       - in: query
- *         name: pointOrder
- *         schema: { type: string, enum: [asc, desc] }
- *         example: desc
+ *         name: sort
+ *         schema:
+ *           type: string
+ *           enum: [recent, old, points_desc, points_asc]
+ *           default: recent
+ *         example: points_desc
+ *         description: 정렬 기준(최근/오래된/포인트 내림차순/오름차순)
  *       - in: query
- *         name: recentOrder
- *         schema: { type: string, enum: [recent, old] }
- *         example: recent
- *       - in: query
- *         name: active
+ *         name: isActive
  *         schema: { type: boolean }
  *         example: true
- *     description: |
- *       - offset: (선택) 건너뛸 레코드 수(기본값 0)
- *       - limit: (선택) 최대 조회 건수(기본값 6, 최대 50)
- *       - keyword: (선택) 스터디 이름/닉네임/내용 검색 키워드(부분 일치)
- *       - pointOrder: (선택) 포인트 합계 기준 정렬(asc/desc, 기본값 desc)
- *       - recentOrder: (선택) 생성일 기준 정렬(recent/old, 기본값 recent)
- *       - active: (선택) 활성화 상태 필터(true/false, 미지정 시 전체)
+ *         description: 활성화 상태 필터(true/false)
  *     responses:
  *       200:
  *         description: 페이징 목록
  *         content:
  *           application/json:
- *             schema: { $ref: '#/components/schemas/StudyListResponse' }
+ *             schema:
+ *               $ref: '#/components/schemas/StudyListResponse'
+ *             examples:
+ *               sample:
+ *                 value:
+ *                   studies:
+ *                     - id: 5
+ *                       nick: 테스트
+ *                       name: 스터디 생성 테스트
+ *                       content: 스터디 생성 테스트 중 입니다.
+ *                       img: https://avatars.githubusercontent.com/in/347564?s=60&v=4
+ *                       isActive: true
+ *                       createdAt: "2025-09-09T01:35:00.041Z"
+ *                       updatedAt: "2025-09-09T01:35:00.041Z"
+ *                       studyEmojis: []
+ *                       point: 0
+ *                     - id: 1
+ *                       nick: 강현우
+ *                       name: 강현우의 운영체제 공부 스터디
+ *                       content: 온라인/오프라인 병행 스터디입니다.
+ *                       img: /img/img-08.png
+ *                       isActive: true
+ *                       createdAt: "2025-09-09T01:14:31.061Z"
+ *                       updatedAt: "2025-09-09T01:14:31.061Z"
+ *                       studyEmojis:
+ *                         - count: 9
+ *                           emoji:
+ *                             id: 1
+ *                             symbol: "🔥"
+ *                       point: 995
+ *                   totalCount: 2
  *       500:
  *         description: 서버 에러
+ *         content:
+ *           application/json:
+ *             schema: { $ref: '#/components/schemas/ErrorResponse' }
  *
  *   post:
  *     tags: [Studies]
@@ -642,37 +677,6 @@
  *         description: 대상 스터디 없음
  *       500:
  *         description: 서버 에러
- */
-
-/**
- * @swagger
- * /api/studies/{studyId}/habit-history:
- *   post:
- *     tags: [Studies]
- *     summary: 주차별 습관 요약(요일 플래그) 갱신
- *     parameters:
- *       - $ref: '#/components/parameters/StudyIdParam'
- *       - in: query
- *         name: habitName
- *         required: true
- *         schema:
- *           type: string
- *           minLength: 1
- *           pattern: '^\\S(.*\\S)?$'
- *           description: 앞뒤 공백 제거 후 비어 있지 않아야 함
- *       - in: query
- *         name: date
- *         required: true
- *         schema: { type: string, enum: [mon, tue, wed, thu, fri, sat, sun] }
- *       - in: header
- *         name: x-study-password
- *         required: false
- *         schema: { type: string }
- *     responses:
- *       200: { description: 갱신된 HabitHistory, content: { application/json: { schema: { $ref: '#/components/schemas/StudyDetail' } } } }
- *       400: { description: 유효성 오류 }
- *       401: { description: 인증 실패 }
- *       404: { description: 대상 없음 }
  */
 
 import express from 'express';


### PR DESCRIPTION
- '스터디 목록 조회' 최신화
- '주차별 습관 요약(요일 플래그) 갱신' 삭제

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **문서(Documentation)**
  - GET /api/studies 문서 개선: 페이징(offset 기본 0, limit 기본 6)과 단일 sort 파라미터(recent/old/points_desc/points_asc) 도입 및 기본값 명시.
  - 파라미터 정리: active → isActive로 변경, keyword/offset/limit 설명 추가.
  - 목록 항목에 studyEmojis(이모지별 카운트 배열)와 point(총점) 필드 반영, 상세 응답에도 studyEmojis 추가.
  - 응답 예시 추가(studies, totalCount 포함) 및 오류 응답(500) 형식 통일.
  - POST /api/studies/{studyId}/habit-history 스웨거 항목 제거.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->