### PR TITLE
fix: 오늘의 습관 비밀번호 인증 제거

### DIFF
--- a/src/api/controllers/habit.controllers.js
+++ b/src/api/controllers/habit.controllers.js
@@ -24,27 +24,25 @@ function parsePositiveParam(req, name) {
   return n;
 }
 
-function parsePassword(req) {
-  const headerPwd = req.get('x-study-password');
-  const bodyPwd =
-    typeof req.body?.password === 'string' ? req.body.password : undefined;
-  const password =
-    typeof headerPwd === 'string' && headerPwd.length > 0 ? headerPwd : bodyPwd;
-  if (!password) {
-    const e = new Error('비밀번호가 필요합니다.');
-    e.status = 400;
-    throw e;
-  }
-  return password;
-}
+// function parsePassword(req) {
+//   const headerPwd = req.get('x-study-password');
+//   const bodyPwd =
+//     typeof req.body?.password === 'string' ? req.body.password : undefined;
+//   const password =
+//     typeof headerPwd === 'string' && headerPwd.length > 0 ? headerPwd : bodyPwd;
+//   if (!password) {
+//     const e = new Error('비밀번호가 필요합니다.');
+//     e.status = 400;
+//     throw e;
+//   }
+//   return password;
+// }
 /*오늘의 습관 조회 */
 async function getTodayHabitsController(req, res, next) {
   try {
     const studyId = parsePositiveParam(req, 'studyId');
-    const password = parsePassword(req);
-    const data = await getTodayHabitsService({ studyId, password });
+    const data = await getTodayHabitsService({ studyId });
     res.set('Cache-Control', 'no-store');
-    res.vary('x-study-password');
     return res.json(data);
   } catch (err) {
     if (err.name === 'UnauthorizedError') {

--- a/src/api/services/habit.services.js
+++ b/src/api/services/habit.services.js
@@ -75,44 +75,44 @@ function getKSTWeekRange(dateInput /* string|Date|undefined */) {
  * 스터디 + 비밀번호 검증 (argon2/평문 seed 지원)
  * - 컨트롤러에서 password 누락은 400으로 걸러지므로 여기서는 불일치만 401 처리
  */
-async function assertStudyWithPassword({ studyId, password }) {
-  const study = await prisma.study.findUnique({
-    where: { id: studyId },
-    select: { id: true, name: true, password: true, isActive: true },
-  });
-  if (!study) {
-    const e = new Error('해당 스터디가 존재하지 않습니다.');
-    e.name = 'NotFoundError';
-    throw e;
-  }
-  if (!study.password) {
-    // 비번이 설정되지 않은 스터디는 정책상 인증 불가로 처리
-    const e = new Error('비밀번호가 필요합니다.');
-    e.name = 'UnauthorizedError';
-    throw e;
-  }
+// async function assertStudyWithPassword({ studyId, password }) {
+//   const study = await prisma.study.findUnique({
+//     where: { id: studyId },
+//     select: { id: true, name: true, password: true, isActive: true },
+//   });
+//   if (!study) {
+//     const e = new Error('해당 스터디가 존재하지 않습니다.');
+//     e.name = 'NotFoundError';
+//     throw e;
+//   }
+//   if (!study.password) {
+//     // 비번이 설정되지 않은 스터디는 정책상 인증 불가로 처리
+//     const e = new Error('비밀번호가 필요합니다.');
+//     e.name = 'UnauthorizedError';
+//     throw e;
+//   }
 
-  let ok = false;
-  const hash = study.password ?? '';
-  try {
-    if (typeof hash === 'string' && hash.startsWith('$argon2')) {
-      ok = await argon2.verify(hash, password);
-    } else {
-      // seed 등 평문 대비
-      ok = password === hash;
-    }
-  } catch {
-    ok = false;
-  }
+//   let ok = false;
+//   const hash = study.password ?? '';
+//   try {
+//     if (typeof hash === 'string' && hash.startsWith('$argon2')) {
+//       ok = await argon2.verify(hash, password);
+//     } else {
+//       // seed 등 평문 대비
+//       ok = password === hash;
+//     }
+//   } catch {
+//     ok = false;
+//   }
 
-  if (!ok) {
-    const e = new Error('비밀번호가 일치하지 않습니다.');
-    e.name = 'UnauthorizedError';
-    throw e;
-  }
+//   if (!ok) {
+//     const e = new Error('비밀번호가 일치하지 않습니다.');
+//     e.name = 'UnauthorizedError';
+//     throw e;
+//   }
 
-  return study;
-}
+//   return study;
+// }
 async function assertStudyExists(studyId) {
   const study = await prisma.study.findUnique({
     where: { id: studyId },
@@ -127,9 +127,9 @@ async function assertStudyExists(studyId) {
 }
 
 /*  GET 오늘의 습관 조회 */
-export default async function getTodayHabitsService({ studyId, password }) {
+export default async function getTodayHabitsService({ studyId }) {
   // 1) 인증
-  const study = await assertStudyWithPassword({ studyId, password });
+  const study = await assertStudyExists(studyId);
 
   // 2) 오늘 범위 계산 (KST)
   const { startUtc, endUtc, nowKstIso, kstDateStr } = getKSTDayRange();
@@ -571,4 +571,4 @@ export async function addTodayHabitService({ studyId, title }) {
     };
   });
 }
-export { getKSTDayRange, getKSTWeekRange, assertStudyWithPassword };
+export { getKSTDayRange, getKSTWeekRange, assertStudyExists };

--- a/src/api/services/habit.services.js
+++ b/src/api/services/habit.services.js
@@ -225,7 +225,7 @@ export async function createTodayHabitsService({ studyId, titles }) {
 }
 
 /* PATCH 오늘의 습관 체크/해제 (토글) */
-export async function toggleHabitService({ habitId }) {
+export async function toggleHabitService({ studyId, habitId }) {
   // 1) 대상 조회
   const target = await prisma.habit.findUnique({
     where: { id: habitId },
@@ -243,7 +243,6 @@ export async function toggleHabitService({ habitId }) {
     throw e;
   } // 교차 검증: 경로의 studyId와 소속이 다르면 거부
   if (studyId && target.habitHistory.studyId !== studyId) {
-    const e = new Error('잘못된 경로 파라미터입니다.');
     e.name = 'BadRequestError';
     e.status = 400;
     throw e;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 오늘의 습관 조회가 비밀번호 없이 이용 가능해졌습니다. 추가 헤더 입력 없이 더 간편하게 호출할 수 있습니다.

- 리팩터링
  - 인증 흐름을 단순화해 비밀번호 기반 검증을 제거했습니다.
  - 요청 요구사항이 간소화되었으며 응답의 캐시 무효화 동작은 유지됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->