### PR TITLE
fix: 프론트와 연동 오류로 인한 수정완료

### DIFF
--- a/src/api/routes/habit.routes.js
+++ b/src/api/routes/habit.routes.js
@@ -376,6 +376,7 @@ import corsMiddleware from '../../common/cors.js';
 // 컨트롤러
 import errorMiddleware from '../../common/error.js'; // 에러 케이스 추가는 여기서 관리
 import {
+  getHabitsQueryController,
   getTodayHabitsController,
   createTodayHabitsController,
   toggleHabitController,
@@ -388,6 +389,7 @@ import {
 const router = express.Router();
 
 router.use(corsMiddleware); // CORS 미들웨어 적용
+router.get('/', errorMiddleware.asyncHandler(getHabitsQueryController));
 
 // 오늘의 습관 조회
 router.get(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 특정 스터디의 일일 습관을 조회하는 GET 엔드포인트 추가. 필수 쿼리: studyId, 선택: date(YYYY-MM-DD). 미지정 시 오늘 기준으로 조회.
  - 응답에 현재 KST 시간, 요청 날짜, 습관 목록, 탐색 링크(오늘로 이동/홈) 포함.
- 오류 처리
  - 유효성 검증 강화: studyId는 1 이상의 정수, date는 YYYY-MM-DD 형식. 위반 시 400 에러와 명확한 메시지 반환.
  - 권한 없음(401), 찾을 수 없음(404), 기타 서버 오류 처리 개선.
- 기타
  - 캐시 방지 헤더 적용(Cache-Control: no-store).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->