### PR TITLE
fix: 토글 API studyId 추가

### DIFF
--- a/src/api/routes/habit.routes.js
+++ b/src/api/routes/habit.routes.js
@@ -218,6 +218,24 @@
  *         in: path
  *         required: true
  *         schema: { type: integer }
+ *       - name: studyId
+ *         in: query
+ *         required: false
+ *         schema: { type: integer }
+ *         description: '선택값. 안전성 검증용으로만 사용(요청값과 실제 소속 불일치 시 400)'
+ *       - name: x-study-id
+ *         in: header
+ *         required: false
+ *         schema: { type: integer }
+ *         description: '선택값. 안전성 검증용으로만 사용'
+ *     requestBody:
+ *       required: false
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               studyId: { type: integer, description: '선택값. 안전성 검증용' }
  *     responses:
  *       '200':
  *         description: 토글 성공
@@ -233,12 +251,12 @@
  *                   format: date-time
  *                   example: '2025-09-02T00:00:00.000Z'
  *                 habitHistoryId: { type: integer, example: 7 }
+ *                 studyId:        { type: integer, example: 101 }
  *       '400': { description: 잘못된 요청, content: { application/json: { schema: { $ref: '#/components/schemas/ErrorResponse' }}}}
  *       '401': { description: 인증 실패,   content: { application/json: { schema: { $ref: '#/components/schemas/ErrorResponse' }}}}
  *       '404': { description: 습관 없음,   content: { application/json: { schema: { $ref: '#/components/schemas/ErrorResponse' }}}}
  *       '500': { description: 서버 오류,   content: { application/json: { schema: { $ref: '#/components/schemas/ErrorResponse' }}}}
  */
-
 /**
  * @swagger
  * /api/habits/week/{studyId}:
@@ -402,7 +420,11 @@ router.post(
   '/today/:studyId/bulk',
   errorMiddleware.asyncHandler(createTodayHabitsController),
 );
-
+// ✅ (선택) 기존 경로 패턴도 임시 지원: /api/habits/today/:studyId/:habitId/toggle
+router.patch(
+  '/today/:studyId/:habitId/toggle',
+  errorMiddleware.asyncHandler(toggleHabitController),
+);
 // 오늘의 습관 체크/해제 (토글)
 router.patch(
   '/:habitId/toggle',

--- a/src/api/services/habit.services.js
+++ b/src/api/services/habit.services.js
@@ -297,6 +297,7 @@ export async function toggleHabitService({ habitId }) {
     isDone: updated.isDone,
     date: updated.date,
     habitHistoryId: updated.habitHistoryId,
+    studyId: target.habitHistory.studyId,
   };
 }
 

--- a/src/common/cors.js
+++ b/src/common/cors.js
@@ -16,7 +16,12 @@ const corsOptions = {
     'https://8-study-forest-team2-ccu0vb250-seongeun95s-projects.vercel.app',
   ], // 허용할 도메인
   methods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE'], // 허용할 HTTP 메서드
-  allowedHeaders: ['Content-Type', 'Authorization', 'x-study-password'], // 허용할 헤더
+  allowedHeaders: [
+    'Content-Type',
+    'Authorization',
+    'x-study-password',
+    'x-study-id',
+  ], // 허용할 헤더
   credentials: true, // 쿠키 인증을 사용함
   optionsSuccessStatus: 200, // 일부 브라우저 호환용
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 습관 토글 API에 선택적 studyId 지원(쿼리, 헤더 x-study-id, 바디, 경로 파라미터).
  - 응답에 studyId 필드가 추가되어 소속 스터디 정보를 확인 가능.
  - 임시 보조 라우트 PATCH /api/habits/today/{studyId}/{habitId}/toggle 제공.
  - CORS 허용 헤더에 x-study-id 추가.

- 문서
  - 습관 토글 엔드포인트에 studyId 파라미터와 응답 스키마(StudyId 포함) 반영.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->