### PR TITLE
hotfix: limit의 제한 해제

### DIFF
--- a/http/study.http
+++ b/http/study.http
@@ -6,10 +6,11 @@
 @studyId = 47
 @pwd = 1234
 # 조회 API를 위한 파라미터 설정
+@limit = 100
 @offset = 0
 @order = points_asc
 @isActive = true
-@keyword = 수정
+@keyword =
 
 ### 1) [로컬] 스터디 관리 페이지 조회 (관리자용)
 
@@ -17,11 +18,11 @@ GET {{base_local}}/studies/manage
 
 ### 2) [배포] 스터디 조회 API (offset, pointOrder, recentOrder, isActive, keyword)
 
-GET {{base_prod}}/studies?offset={{offset}}&sort={{order}}&isActive={{isActive}}&keyword={{keyword}}
+GET {{base_prod}}/studies?limit={{limit}}&offset={{offset}}&sort={{order}}&isActive={{isActive}}&keyword={{keyword}}
 
 ### 2) [로컬] 스터디 조회 API (offset, pointOrder, recentOrder, isActive, keyword)
 
-GET {{base_local}}/studies?offset={{offset}}&sort={{order}}&isActive={{isActive}}&keyword={{keyword}}
+GET {{base_local}}/studies?limit={{limit}}&offset={{offset}}&sort={{order}}&isActive={{isActive}}&keyword={{keyword}}
 
 ### 3) [배포] 스터디 생성 API
 

--- a/src/api/controllers/study.controllers.js
+++ b/src/api/controllers/study.controllers.js
@@ -31,8 +31,7 @@ async function controlStudyList(req, res) {
   const limitNum = Number.parseInt(limitStr, 10);
 
   const offset = Number.isInteger(offsetNum) && offsetNum >= 0 ? offsetNum : 0;
-  const limit =
-    Number.isInteger(limitNum) && limitNum > 0 && limitNum <= 50 ? limitNum : 6;
+  const limit = Number.isInteger(limitNum) && limitNum >= 0 ? limitNum : 0;
 
   // 2) 정렬 단일화: sort (recent | old | points_desc | points_asc)
   //    - 한국어 라벨 및 레거시 파라미터(recentOrder/pointOrder)도 매핑 지원

--- a/src/api/services/study.services.js
+++ b/src/api/services/study.services.js
@@ -52,10 +52,9 @@ async function serviceStudyList(options) {
   const limit =
     typeof rawLimit === 'number' &&
     Number.isInteger(rawLimit) &&
-    rawLimit > 0 &&
-    rawLimit <= 50
+    rawLimit >= 0
       ? rawLimit
-      : 6;
+      : 0;
   const sort = typeof rawSort === 'string' ? rawSort : 'recent';
 
   const hasIsActive = typeof rawIsActive === 'boolean';


### PR DESCRIPTION
- 50까지의 제한을 해제하였습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 스터디 목록 API에 limit 파라미터를 공식 지원합니다. 최대 50개까지 반환하며, 0 지정 시 0건 반환이 가능합니다.

- Changes
  - 기본 키워드 필터를 제거하고 기본값을 빈 문자열로 변경했습니다.
  - 기본 limit 동작을 6에서 0으로 조정했습니다(미지정/유효하지 않은 경우 0건 반환). 요청 시 limit 포함을 권장합니다.
  - 프로덕션/로컬 요청 형식을 통일했습니다: limit, offset, sort(order), isActive, keyword 쿼리 사용.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->